### PR TITLE
Add IOpt tuner

### DIFF
--- a/docs/source/api/tuning.rst
+++ b/docs/source/api/tuning.rst
@@ -31,9 +31,23 @@ Initialize ``SearchSpace`` with dictionary of the form
 Simultaneous
 ~~~~~~~~~~~~
 
-You can tune all parameters of graph nodes simultaneously using ``SimultaneousTuner``.
+You can tune all parameters of graph nodes simultaneously using ``SimultaneousTuner`` or ``IOptTuner``.
+
+.. note::
+   ``IOptTuner`` implements deterministic algorithm.
+
+   For now ``IOptTuner`` can not be constrained by time, so constrain execution by number of iterations.
+
+   Also ``IOptTuner`` can optimise only `continuous` and `discrete` parameters but not `categorical` ones.
+   `Categorical` parameters will be ignored while tuning.
+
+   ``IOptTuner`` is implemented using `IOpt library`_. See the `documentation`_ (in russian) to learn more about
+   the optimisation algorithm.
 
 .. automodule:: golem.core.tuning.simultaneous
+   :members:
+
+.. automodule:: golem.core.tuning.iopt_tuner
    :members:
 
 Sequential
@@ -45,3 +59,5 @@ Sequential
    :members:
 
 .. _Adaptation of Graphs: https://thegolem.readthedocs.io/en/latest/advanced/adaptation.html
+.. _IOpt library: https://github.com/aimclub/iOpt
+.. _documentation: https://iopt.readthedocs.io/ru/latest/introduction.html

--- a/docs/source/api/tuning.rst
+++ b/docs/source/api/tuning.rst
@@ -9,7 +9,7 @@ To specify parameters search space use ``SearchSpace`` class.
 Initialize ``SearchSpace`` with dictionary of the form
 ``{'operation_name': {'param_name': { 'hyperopt-dist': <hyperopt distribution function>,
 'sampling-scope': [sampling scope], 'type': <type of parameter>}, ...}, ...}``.
-Three type of parameters are available: `continuous`, `discrete` and `categorical`.
+Three types of parameters are available: `continuous`, `discrete` and `categorical`.
 
 .. code::
 
@@ -55,7 +55,7 @@ You can tune all parameters of graph nodes simultaneously using ``SimultaneousTu
    Also ``IOptTuner`` can optimise only `continuous` and `discrete` parameters but not `categorical` ones.
    `Categorical` parameters will be ignored while tuning.
 
-   ``IOptTuner`` is implemented using `IOpt library`_. See the `documentation`_ (in russian) to learn more about
+   ``IOptTuner`` is implemented using `IOpt library`_. See the `documentation`_ (in Russian) to learn more about
    the optimisation algorithm.
 
 .. automodule:: golem.core.tuning.simultaneous

--- a/docs/source/api/tuning.rst
+++ b/docs/source/api/tuning.rst
@@ -1,13 +1,15 @@
 Tuning of graph parameters
 ==========================
 
-``SimultaneousTuner`` and ``SequentialTuner`` work with internal graph representation (also called `optimization graph`, see `Adaptation of Graphs`_).
+``SimultaneousTuner``, ``IOptTuner`` and ``SequentialTuner`` work with internal graph representation (also called `optimization graph`, see `Adaptation of Graphs`_).
 To optimise custom domain graph pass ``adapter``. If your graph class is inherited from ``OptGraph`` no adapter is needed.
 Tuners optimise parameters stored in ``OptNode.parameters``.
 
 To specify parameters search space use ``SearchSpace`` class.
 Initialize ``SearchSpace`` with dictionary of the form
-``{'operation_name': {'param_name': (hyperopt distribution function, [sampling scope]), ...}, ...}``.
+``{'operation_name': {'param_name': { 'hyperopt-dist': <hyperopt distribution function>,
+'sampling-scope': [sampling scope], 'type': <type of parameter>}, ...}, ...}``.
+Three type of parameters are available: `continuous`, `discrete` and `categorical`.
 
 .. code::
 
@@ -18,12 +20,24 @@ Initialize ``SearchSpace`` with dictionary of the form
 
     params_per_operation = {
         'operation_name_1': {
-            'parameter_name_1': (hp.uniformint, [2, 7]),
-            'parameter_name_2': (hp.loguniform, [np.log(1e-3), np.log(1)])
+            'parameter_name_1': {
+                'hyperopt-dist': hp.uniformint,
+                'sampling-scope': [2, 21],
+                'type': 'discrete'},
+            'parameter_name_2': {
+                'hyperopt-dist': hp.loguniform,
+                'sampling-scope': [1e-3, 1],
+                'type': 'continuous'}
         },
         'operation_name_2': {
-            'parameter_name_1': (hp.choice, [["first", "second", "third"]]),
-            'parameter_name_2': (hp.uniform, [0.05, 1.0])
+            'parameter_name_1': {
+                'hyperopt-dist': hp.choice,
+                'sampling-scope': [["first", "second", "third"]],
+                'type': 'categorical'},
+            'parameter_name_2':
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [0.05, 1.0],
+                'type': 'continuous'}
         }}
 
     search_space = SearchSpace(params_per_operation)
@@ -47,7 +61,7 @@ You can tune all parameters of graph nodes simultaneously using ``SimultaneousTu
 .. automodule:: golem.core.tuning.simultaneous
    :members:
 
-.. automodule:: golem.core.tuning.iopt_tuner
+.. autoclass:: golem.core.tuning.iopt_tuner.IOptTuner
    :members:
 
 Sequential

--- a/golem/core/tuning/hyperopt_tuner.py
+++ b/golem/core/tuning/hyperopt_tuner.py
@@ -1,0 +1,122 @@
+from abc import ABC
+from datetime import timedelta
+from typing import Optional, Callable, Dict
+
+import numpy as np
+from hyperopt import tpe, hp
+from hyperopt.early_stop import no_progress_loss
+from hyperopt.pyll import Apply
+
+from golem.core.adapter import BaseOptimizationAdapter
+from golem.core.log import default_log
+from golem.core.optimisers.objective import ObjectiveFunction
+from golem.core.optimisers.timer import Timer
+from golem.core.tuning.search_space import SearchSpace, get_node_operation_parameter_label
+from golem.core.tuning.tuner_interface import BaseTuner
+
+
+class HyperoptTuner(BaseTuner, ABC):
+    """Base class for hyperparameters optimization based on hyperopt library
+
+    Args:
+      objective_evaluate: objective to optimize
+      adapter: the function for processing of external object that should be optimized
+      search_space: SearchSpace instance
+      iterations: max number of iterations
+      early_stopping_rounds: Optional max number of stagnating iterations for early stopping. If ``None``, will be set
+          to ``max(100, int(np.sqrt(iterations) * 10))``.
+      timeout: max time for tuning
+      n_jobs: num of ``n_jobs`` for parallelization (``-1`` for use all cpu's)
+      deviation: required improvement (in percent) of a metric to return tuned graph.
+        By default, ``deviation=0.05``, which means that tuned graph will be returned
+        if it's metric will be at least 0.05% better than the initial.
+      algo: algorithm for hyperparameters optimization with signature similar to :obj:`hyperopt.tse.suggest`
+    """
+
+    def __init__(self, objective_evaluate: ObjectiveFunction,
+                 search_space: SearchSpace,
+                 adapter: Optional[BaseOptimizationAdapter] = None,
+                 iterations: int = 100,
+                 early_stopping_rounds: Optional[int] = None,
+                 timeout: timedelta = timedelta(minutes=5),
+                 n_jobs: int = -1,
+                 deviation: float = 0.05,
+                 algo: Callable = tpe.suggest):
+        early_stopping_rounds = early_stopping_rounds or max(100, int(np.sqrt(iterations) * 10))
+        super().__init__(objective_evaluate,
+                         search_space,
+                         adapter,
+                         iterations,
+                         early_stopping_rounds,
+                         timeout,
+                         n_jobs,
+                         deviation)
+
+        self.early_stop_fn = no_progress_loss(iteration_stop_count=self.early_stopping_rounds)
+        self.max_seconds = int(timeout.seconds) if timeout is not None else None
+        self.algo = algo
+        self.log = default_log(self)
+
+    def _update_remaining_time(self, tuner_timer: Timer):
+        self.max_seconds = self.max_seconds - tuner_timer.minutes_from_start * 60
+
+
+def get_parameter_hyperopt_space(search_space: SearchSpace,
+                                 operation_name: str,
+                                 parameter_name: str,
+                                 label: str = 'default') -> Optional[Apply]:
+    """
+    Function return hyperopt object with search_space from search_space dictionary
+
+    Args:
+        search_space: SearchSpace with parameters per operation
+        operation_name: name of the operation
+        parameter_name: name of hyperparameter of particular operation
+        label: label to assign in hyperopt pyll
+
+    Returns:
+        parameter range
+    """
+
+    # Get available parameters for current operation
+    operation_parameters = search_space.parameters_per_operation.get(operation_name)
+
+    if operation_parameters is not None:
+        parameter_properties = operation_parameters.get(parameter_name)
+        hyperopt_distribution = parameter_properties.get('hyperopt-dist')
+        sampling_scope = parameter_properties.get('sampling-scope')
+        if hyperopt_distribution == hp.loguniform:
+            sampling_scope = [np.log(x) for x in sampling_scope]
+        return hyperopt_distribution(label, *sampling_scope)
+    else:
+        return None
+
+
+def get_node_parameters_for_hyperopt(search_space: SearchSpace, node_id: int, operation_name: str) \
+        -> Dict[str, Apply]:
+    """
+    Function for forming dictionary with hyperparameters of the node operation for the ``HyperoptTuner``
+
+    Args:
+        search_space: SearchSpace with parameters per operation
+        node_id: number of node in graph.nodes list
+        operation_name: name of operation in the node
+
+    Returns:
+        parameters_dict: dictionary-like structure with labeled hyperparameters
+        and their range per operation
+    """
+
+    # Get available parameters for current operation
+    parameters_list = search_space.get_parameters_for_operation(operation_name)
+
+    parameters_dict = {}
+    for parameter_name in parameters_list:
+        node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
+
+        # For operation get range where search can be done
+        space = get_parameter_hyperopt_space(search_space, operation_name, parameter_name, node_op_parameter_name)
+
+        parameters_dict.update({node_op_parameter_name: space})
+
+    return parameters_dict

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -49,7 +49,8 @@ class IOptProblemParameters:
 
 
 class GolemProblem(Problem, Generic[DomainGraphForTune]):
-    def __init__(self, graph: DomainGraphForTune, objective_evaluate: ObjectiveEvaluate,
+    def __init__(self, graph: DomainGraphForTune,
+                 objective_evaluate: ObjectiveEvaluate,
                  problem_parameters: IOptProblemParameters):
         super().__init__()
         self.objective_evaluate = objective_evaluate
@@ -223,7 +224,8 @@ class IOptTuner(BaseTuner):
         return parameters_dict, initial_parameters
 
 
-def get_node_parameters_for_iopt(search_space: SearchSpace, node_id: int, operation_name: str):
+def get_node_parameters_for_iopt(search_space: SearchSpace, node_id: int, operation_name: str) \
+        -> Tuple[Dict[str, List], Dict[str, List]]:
     """
     Method for forming dictionary with hyperparameters of node operation for the ``IOptTuner``
 

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -1,0 +1,137 @@
+from dataclasses import dataclass, field
+from typing import List, Dict, Generic, Tuple, Any
+
+import numpy as np
+from iOpt.method.listener import ConsoleFullOutputListener
+from iOpt.problem import Problem
+from iOpt.solver import Solver
+from iOpt.solver_parametrs import SolverParameters
+from iOpt.trial import Point, FunctionValue
+
+from golem.core.adapter import BaseOptimizationAdapter
+from golem.core.optimisers.graph import OptGraph
+from golem.core.optimisers.objective import ObjectiveEvaluate
+from golem.core.tuning.tuner_interface import BaseTuner, DomainGraphForTune
+
+
+@dataclass
+class IOptProblemParameters:
+    float_params_names: List[str] = field(default_factory=list)
+    discrete_params_names: List[str] = field(default_factory=list)
+    lower_bounds_of_float_params: List[float] = field(default_factory=list)
+    upper_bounds_of_float_params: List[float] = field(default_factory=list)
+    discrete_params_vals: List[List[Any]] = field(default_factory=list)
+
+    def append_float_parameter(self, name: str, bounds: List):
+        self.float_params_names.append(name)
+        self.lower_bounds_of_float_params.append(bounds[0])
+        self.upper_bounds_of_float_params.append(bounds[1])
+
+    def append_discrete_parameters(self, name: str, values: List):
+        self.discrete_params_names.append(name)
+        self.discrete_params_vals.append(values)
+
+
+class GolemProblem(Problem, Generic[DomainGraphForTune]):
+    def __init__(self, graph: DomainGraphForTune, objective_evaluate: ObjectiveEvaluate,
+                 problem_parameters: IOptProblemParameters,
+                 n_jobs: int = -1):
+        super().__init__()
+        self.n_jobs = n_jobs
+        objective_evaluate.eval_n_jobs = self.n_jobs
+        self.objective_evaluate = objective_evaluate.evaluate
+        self.graph = graph
+
+        self.numberOfObjectives = 1
+        self.numberOfConstraints = 0
+
+        self.discreteVariableNames = problem_parameters.discrete_params_names
+        self.discreteVariableValues = problem_parameters.discrete_params_vals
+        self.numberOfDiscreteVariables = len(self.discreteVariableNames)
+
+        self.floatVariableNames = problem_parameters.float_params_names
+        self.lowerBoundOfFloatVariables = problem_parameters.lower_bounds_of_float_params
+        self.upperBoundOfFloatVariables = problem_parameters.upper_bounds_of_float_params
+        self.numberOfFloatVariables = len(self.floatVariableNames)
+
+        self._default_metric_value = np.inf
+
+    def Calculate(self, point: Point, functionValue: FunctionValue) -> FunctionValue:
+        new_params = get_parameters_dict_from_iopt_point(point, self.floatVariableNames, self.discreteVariableNames)
+        BaseTuner.set_arg_graph(self.graph, new_params)
+        graph_fitness = self.objective_evaluate(self.graph)
+        metric_value = graph_fitness.value if graph_fitness.valid else self._default_metric_value
+        functionValue.value = metric_value
+        return functionValue
+
+
+class IOptTuner(BaseTuner):
+    def __init__(self, objective_evaluate: ObjectiveEvaluate,
+                 adapter: BaseOptimizationAdapter = None,
+                 iterations=100,
+                 n_jobs: int = -1):
+        super().__init__(objective_evaluate, adapter, iterations, n_jobs)
+
+    def tune(self, graph: DomainGraphForTune) -> DomainGraphForTune:
+        graph = self.adapter.adapt(graph)
+
+        problem_parameters, initial_parameters = self._get_parameters_for_tune(graph)
+
+        # initial_point = Point(floatVariables=initial_parameters['float'],
+        #                       discreteVariables=initial_parameters['discrete'])
+
+        # float_params_names = parameters_dict['float'].keys()
+        # discrete_params_names = parameters_dict['discrete'].keys()
+        #
+        # lower_bounds = [bounds[0] for bounds in parameters_dict['float'].values()]
+        # upper_bounds = [bounds[1] for bounds in parameters_dict['float'].values()]
+        #
+        # bounds_of_float_params = {'low': lower_bounds, 'upper': upper_bounds}
+        # discrete_params_vals = list(parameters_dict['discrete'].values())
+
+        # problem = GolemProblem(graph, self.objective_evaluate, float_params_names,
+        #                        discrete_params_names, bounds_of_float_params, discrete_params_vals)
+
+        initial_point = Point(**initial_parameters) if initial_parameters else None
+
+        problem = GolemProblem(graph, self.objective_evaluate, problem_parameters)
+
+        method_params = SolverParameters(r=np.double(3.0), itersLimit=self.iterations, startPoint=initial_point)
+        solver = Solver(problem, parameters=method_params)
+
+        cfol = ConsoleFullOutputListener(mode='full')
+        solver.AddListener(cfol)
+
+        solution = solver.Solve()
+        best_point = solution.bestTrials[0].point
+        best_params = get_parameters_dict_from_iopt_point(best_point, problem_parameters.float_params_names,
+                                                          problem_parameters.discrete_params_names)
+        tuned_graph = self.set_arg_graph(graph, best_params)
+        tuned_graph = self.adapter.restore(tuned_graph)
+        return tuned_graph
+
+    def _get_parameters_for_tune(self, graph: OptGraph) -> Tuple[IOptProblemParameters, dict]:
+        """ Method for defining the search space
+
+        Args:
+            graph: graph to be tuned
+
+        Returns:
+            parameters_dict: dict with operation names and parameters
+            initial_parameters: dict with initial parameters of the graph
+        """
+        parameters_dict = IOptProblemParameters()
+        # must be full
+        initial_parameters = {}
+
+        return parameters_dict, initial_parameters
+
+
+def get_parameters_dict_from_iopt_point(point: Point, float_params_names: List[str], discrete_params_names: List[str]) \
+        -> Dict[str, Any]:
+    float_params = dict(zip(float_params_names, point.floatVariables)) \
+        if point.floatVariables is not None else {}
+    discrete_params = dict(zip(discrete_params_names, point.discreteVariables)) \
+        if point.discreteVariables is not None else {}
+    params_dict = {**float_params, **discrete_params}
+    return params_dict

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -128,13 +128,13 @@ class IOptTuner(BaseTuner):
                  evolvent_density: int = 10,
                  eps_r: float = 0.001,
                  refine_solution: bool = False,
-                 deviation: float = 0.05):
+                 deviation: float = 0.05, **kwargs):
         super().__init__(objective_evaluate,
                          search_space,
                          adapter,
                          iterations=iterations,
                          n_jobs=n_jobs,
-                         deviation=deviation)
+                         deviation=deviation, **kwargs)
         self.solver_parameters = SolverParameters(r=np.double(r),
                                                   eps=np.double(eps),
                                                   itersLimit=iterations,

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Dict, Generic, Tuple, Any
+from typing import List, Dict, Generic, Tuple, Any, Optional
 
 import numpy as np
 from iOpt.method.listener import ConsoleFullOutputListener
@@ -11,6 +11,7 @@ from iOpt.trial import Point, FunctionValue
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.objective import ObjectiveEvaluate
+from golem.core.tuning.search_space import SearchSpace
 from golem.core.tuning.tuner_interface import BaseTuner, DomainGraphForTune
 
 
@@ -22,12 +23,35 @@ class IOptProblemParameters:
     upper_bounds_of_float_params: List[float] = field(default_factory=list)
     discrete_params_vals: List[List[Any]] = field(default_factory=list)
 
+    @staticmethod
+    def from_parameters_dicts(float_parameters_dict: Optional[Dict[str, List]] = None,
+                              discrete_parameters_dict: Optional[Dict[str, List]] = None):
+        float_parameters_dict = float_parameters_dict or {}
+        discrete_parameters_dict = discrete_parameters_dict or {}
+
+        float_params_names = list(float_parameters_dict.keys())
+        discrete_params_names = list(discrete_parameters_dict.keys())
+
+        lower_bounds_of_float_params = [bounds[0] for bounds in float_parameters_dict.values()]
+        upper_bounds_of_float_params = [bounds[1] for bounds in float_parameters_dict.values()]
+        discrete_params_vals = [values_set for values_set in discrete_parameters_dict.values()]
+
+        # TODO: Remove - for now IOpt handles only float variables, so we append discrete parameters to float ones
+        float_params_names.extend(discrete_params_names)
+        lower_bounds_of_discrete_params = [bounds[0] for bounds in discrete_parameters_dict.values()]
+        upper_bounds_of_discrete_params = [bounds[1] for bounds in discrete_parameters_dict.values()]
+        lower_bounds_of_float_params.extend(lower_bounds_of_discrete_params)
+        upper_bounds_of_float_params.extend(upper_bounds_of_discrete_params)
+
+        return IOptProblemParameters(float_params_names, discrete_params_names, lower_bounds_of_float_params,
+                                     upper_bounds_of_float_params, discrete_params_vals)
+
     def append_float_parameter(self, name: str, bounds: List):
         self.float_params_names.append(name)
         self.lower_bounds_of_float_params.append(bounds[0])
         self.upper_bounds_of_float_params.append(bounds[1])
 
-    def append_discrete_parameters(self, name: str, values: List):
+    def append_discrete_parameter(self, name: str, values: List):
         self.discrete_params_names.append(name)
         self.discrete_params_vals.append(values)
 
@@ -67,30 +91,16 @@ class GolemProblem(Problem, Generic[DomainGraphForTune]):
 
 class IOptTuner(BaseTuner):
     def __init__(self, objective_evaluate: ObjectiveEvaluate,
+                 search_space: SearchSpace,
                  adapter: BaseOptimizationAdapter = None,
-                 iterations=100,
+                 iterations: int = 100,
                  n_jobs: int = -1):
-        super().__init__(objective_evaluate, adapter, iterations, n_jobs)
+        super().__init__(objective_evaluate, search_space, adapter, iterations, n_jobs)
 
     def tune(self, graph: DomainGraphForTune) -> DomainGraphForTune:
         graph = self.adapter.adapt(graph)
 
         problem_parameters, initial_parameters = self._get_parameters_for_tune(graph)
-
-        # initial_point = Point(floatVariables=initial_parameters['float'],
-        #                       discreteVariables=initial_parameters['discrete'])
-
-        # float_params_names = parameters_dict['float'].keys()
-        # discrete_params_names = parameters_dict['discrete'].keys()
-        #
-        # lower_bounds = [bounds[0] for bounds in parameters_dict['float'].values()]
-        # upper_bounds = [bounds[1] for bounds in parameters_dict['float'].values()]
-        #
-        # bounds_of_float_params = {'low': lower_bounds, 'upper': upper_bounds}
-        # discrete_params_vals = list(parameters_dict['discrete'].values())
-
-        # problem = GolemProblem(graph, self.objective_evaluate, float_params_names,
-        #                        discrete_params_names, bounds_of_float_params, discrete_params_vals)
 
         initial_point = Point(**initial_parameters) if initial_parameters else None
 
@@ -120,10 +130,28 @@ class IOptTuner(BaseTuner):
             parameters_dict: dict with operation names and parameters
             initial_parameters: dict with initial parameters of the graph
         """
-        parameters_dict = IOptProblemParameters()
-        # must be full
-        initial_parameters = {}
+        float_parameters_dict = {}
+        discrete_parameters_dict = {}
+        initial_parameters = {'floatVariables': [], 'discreteVariables': []}
+        for node_id, node in enumerate(graph.nodes):
+            operation_name = node.name
 
+            # Assign unique prefix for each model hyperparameter
+            # label - number of node in the graph
+            float_node_params, discrete_node_params = self.search_space.get_node_params_for_iopt(
+                node_id=node_id, operation_name=operation_name)
+
+            for parameter, bounds in float_node_params.items():
+                initaial_value = node.parameters.get(parameter) or bounds[0]
+                initial_parameters['floatVariables'].append(initaial_value)
+
+            for parameter, bounds in discrete_node_params.items():
+                initaial_value = node.parameters.get(parameter) or bounds[0]
+                initial_parameters['discreteVariables'].append(initaial_value)
+
+            float_parameters_dict.update(float_node_params)
+            discrete_parameters_dict.update(discrete_node_params)
+        parameters_dict = IOptProblemParameters.from_parameters_dicts(float_parameters_dict, discrete_parameters_dict)
         return parameters_dict, initial_parameters
 
 
@@ -133,5 +161,12 @@ def get_parameters_dict_from_iopt_point(point: Point, float_params_names: List[s
         if point.floatVariables is not None else {}
     discrete_params = dict(zip(discrete_params_names, point.discreteVariables)) \
         if point.discreteVariables is not None else {}
+
+    # TODO: Remove workaround - for now IOpt handles only float variables, so discrete parameters
+    #  are optimized as continuous and we need to round them
+    for parameter_name in float_params:
+        if parameter_name in discrete_params_names:
+            float_params[parameter_name] = round(float_params[parameter_name])
+
     params_dict = {**float_params, **discrete_params}
     return params_dict

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -202,9 +202,9 @@ class IOptTuner(BaseTuner):
 
             # Assign unique prefix for each model hyperparameter
             # label - number of node in the graph
-            float_node_parameters, discrete_node_parameters = self.get_node_parameters(
-                node_id=node_id,
-                operation_name=operation_name)
+            float_node_parameters, discrete_node_parameters = get_node_parameters_for_iopt(self.search_space,
+                                                                                           node_id,
+                                                                                           operation_name)
 
             # Set initial parameters for search
             for parameter, bounds in float_node_parameters.items():
@@ -222,37 +222,39 @@ class IOptTuner(BaseTuner):
         parameters_dict = IOptProblemParameters.from_parameters_dicts(float_parameters_dict, discrete_parameters_dict)
         return parameters_dict, initial_parameters
 
-    def get_node_parameters(self, node_id, operation_name):
-        """
-        Method for forming dictionary with hyperparameters of node operation for the ``IOptTuner``
 
-        Args:
-            node_id: number of node in graph.nodes list
-            operation_name: name of operation in the node
+def get_node_parameters_for_iopt(search_space: SearchSpace, node_id: int, operation_name: str):
+    """
+    Method for forming dictionary with hyperparameters of node operation for the ``IOptTuner``
 
-        Returns:
-            float_parameters_dict: dictionary-like structure with labeled float hyperparameters
-            and their range per operation
-            discrete_parameters_dict: dictionary-like structure with labeled discrete hyperparameters
-            and their range per operation
-        """
-        # Get available parameters for operation
-        parameters_dict = self.search_space.parameters_per_operation.get(operation_name)
+    Args:
+        search_space: SearchSpace with parameters per operation
+        node_id: number of node in graph.nodes list
+        operation_name: name of operation in the node
 
-        discrete_parameters_dict = {}
-        float_parameters_dict = {}
+    Returns:
+        float_parameters_dict: dictionary-like structure with labeled float hyperparameters
+        and their range per operation
+        discrete_parameters_dict: dictionary-like structure with labeled discrete hyperparameters
+        and their range per operation
+    """
+    # Get available parameters for operation
+    parameters_dict = search_space.parameters_per_operation.get(operation_name)
 
-        if parameters_dict is not None:
+    discrete_parameters_dict = {}
+    float_parameters_dict = {}
 
-            for parameter_name, parameter_properties in parameters_dict.items():
-                node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
+    if parameters_dict is not None:
 
-                parameter_type = parameter_properties.get('type')
-                if parameter_type == 'discrete':
-                    discrete_parameters_dict.update({node_op_parameter_name: parameter_properties
-                                                    .get('sampling-scope')})
-                elif parameter_type == 'continuous':
-                    float_parameters_dict.update({node_op_parameter_name: parameter_properties
-                                                 .get('sampling-scope')})
+        for parameter_name, parameter_properties in parameters_dict.items():
+            node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
 
-        return float_parameters_dict, discrete_parameters_dict
+            parameter_type = parameter_properties.get('type')
+            if parameter_type == 'discrete':
+                discrete_parameters_dict.update({node_op_parameter_name: parameter_properties
+                                                .get('sampling-scope')})
+            elif parameter_type == 'continuous':
+                float_parameters_dict.update({node_op_parameter_name: parameter_properties
+                                             .get('sampling-scope')})
+
+    return float_parameters_dict, discrete_parameters_dict

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -127,8 +127,9 @@ class IOptTuner(BaseTuner):
         if no_parameters_to_optimize:
             self._stop_tuning_with_message(f'Graph "{graph.graph_description}" has no parameters to optimize')
         else:
-            initial_point = Point(**initial_parameters) if initial_parameters else None
-            self.solver_parameters.startPoint = initial_point
+            if initial_parameters:
+                initial_point = Point(**initial_parameters)
+                self.solver_parameters.startPoint = initial_point
 
             problem = GolemProblem(graph, self.objective_evaluate, problem_parameters)
             solver = Solver(problem, parameters=self.solver_parameters)

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -111,10 +111,17 @@ class IOptTuner(BaseTuner):
                  eps_r: float = 0.001,
                  refine_solution: bool = False,
                  deviation: float = 0.05):
-        super().__init__(objective_evaluate=objective_evaluate, search_space=search_space, adapter=adapter,
-                         iterations=iterations, n_jobs=n_jobs, deviation=deviation)
-        self.solver_parameters = SolverParameters(r=np.double(r), eps=np.double(eps), itersLimit=iterations,
-                                                  evolventDensity=evolvent_density, epsR=np.double(eps_r),
+        super().__init__(objective_evaluate,
+                         search_space,
+                         adapter,
+                         iterations=iterations,
+                         n_jobs=n_jobs,
+                         deviation=deviation)
+        self.solver_parameters = SolverParameters(r=np.double(r),
+                                                  eps=np.double(eps),
+                                                  itersLimit=iterations,
+                                                  evolventDensity=evolvent_density,
+                                                  epsR=np.double(eps_r),
                                                   refineSolution=refine_solution)
 
     def tune(self, graph: DomainGraphForTune, show_progress: bool = True) -> DomainGraphForTune:
@@ -191,9 +198,9 @@ class IOptTuner(BaseTuner):
         return parameters_dict, initial_parameters
 
 
-def get_parameters_dict_from_iopt_point(point: Point, float_parameters_names: List[str],
-                                        discrete_parameters_names: List[str]) \
-        -> Dict[str, Any]:
+def get_parameters_dict_from_iopt_point(point: Point,
+                                        float_parameters_names: List[str],
+                                        discrete_parameters_names: List[str]) -> Dict[str, Any]:
     """Constructs a dict with all hyperparameters """
     float_parameters = dict(zip(float_parameters_names, point.floatVariables)) \
         if point.floatVariables is not None else {}

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -146,13 +146,13 @@ class IOptTuner(BaseTuner):
         graph = self.adapter.adapt(graph)
         problem_parameters, initial_parameters = self._get_parameters_for_tune(graph)
 
-        self.init_check(graph)
-
         no_parameters_to_optimize = (not problem_parameters.discrete_parameters_names and
                                      not problem_parameters.float_parameters_names)
         if no_parameters_to_optimize:
             self._stop_tuning_with_message(f'Graph "{graph.graph_description}" has no parameters to optimize')
         else:
+            self.init_check(graph)
+
             if initial_parameters:
                 initial_point = Point(**initial_parameters)
                 self.solver_parameters.startPoint = initial_point

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -95,7 +95,7 @@ class IOptTuner(BaseTuner):
                                                   evolventDensity=evolvent_density, epsR=np.double(eps_r),
                                                   refineSolution=refine_solution)
 
-    def tune(self, graph: DomainGraphForTune) -> DomainGraphForTune:
+    def tune(self, graph: DomainGraphForTune, show_progress: bool = True) -> DomainGraphForTune:
         graph = self.adapter.adapt(graph)
         problem_parameters, initial_parameters = self._get_parameters_for_tune(graph)
 
@@ -112,8 +112,9 @@ class IOptTuner(BaseTuner):
             problem = GolemProblem(graph, self.objective_evaluate, problem_parameters)
             solver = Solver(problem, parameters=self.solver_parameters)
 
-            console_output = ConsoleFullOutputListener(mode='full')
-            solver.AddListener(console_output)
+            if show_progress:
+                console_output = ConsoleFullOutputListener(mode='full')
+                solver.AddListener(console_output)
 
             solution = solver.Solve()
             best_point = solution.bestTrials[0].point

--- a/golem/core/tuning/search_space.py
+++ b/golem/core/tuning/search_space.py
@@ -17,61 +17,6 @@ class SearchSpace:
     def __init__(self, search_space: Dict[str, Dict[str, Dict[str, Union[Callable, List, str]]]]):
         self.parameters_per_operation = search_space
 
-    def get_parameter_hyperopt_space(self, operation_name: str, parameter_name: str, label: str = 'default'):
-        """
-        Method return hyperopt object with search_space from search_space dictionary
-
-        Args:
-            operation_name: name of the operation
-            parameter_name: name of hyperparameter of particular operation
-            label: label to assign in hyperopt pyll
-
-        Returns:
-            dictionary with appropriate range
-        """
-
-        # Get available parameters for current operation
-        operation_parameters = self.parameters_per_operation.get(operation_name)
-
-        if operation_parameters is not None:
-            parameter_properties = operation_parameters.get(parameter_name)
-            hyperopt_distribution = parameter_properties.get('hyperopt-dist')
-            sampling_scope = parameter_properties.get('sampling-scope')
-            if hyperopt_distribution == hp.loguniform:
-                sampling_scope = [np.log(x) for x in sampling_scope]
-            return hyperopt_distribution(label, *sampling_scope)
-        else:
-            return None
-
-    def get_node_parameters_for_hyperopt(self, node_id, operation_name):
-        """
-        Method for forming dictionary with hyperparameters of the node operation for the ``HyperoptTuner``
-
-        Args:
-            node_id: number of node in graph.nodes list
-            operation_name: name of operation in the node
-
-        Returns:
-            parameters_dict: dictionary-like structure with labeled hyperparameters
-            and their range per operation
-        """
-
-        # Get available parameters for current operation
-        parameters_list = self.get_parameters_for_operation(operation_name)
-
-        parameters_dict = {}
-        for parameter_name in parameters_list:
-            node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
-
-            # For operation get range where search can be done
-            space = self.get_parameter_hyperopt_space(operation_name=operation_name,
-                                                      parameter_name=parameter_name,
-                                                      label=node_op_parameter_name)
-
-            parameters_dict.update({node_op_parameter_name: space})
-
-        return parameters_dict
-
     def get_node_parameters_for_iopt(self, node_id, operation_name):
         """
         Method for forming dictionary with hyperparameters of node operation for the ``IOptTuner``

--- a/golem/core/tuning/search_space.py
+++ b/golem/core/tuning/search_space.py
@@ -9,9 +9,12 @@ class SearchSpace:
     Args:
         search_space: dictionary with parameters and their search_space
             {'operation_name': {'param_name': {'hyperopt-dist': hyperopt distribution function,
-            'sampling-scope': [sampling scope], 'type': 'discrete' or 'continuous'}, ...}, ...},
-            e.g. ``{'operation_name': {'param1': {'hyperopt-dist': hp.uniformint, 'sampling-scope': [2, 21]),
-            'type': 'discrete'}, ...}, ..}
+                                               'sampling-scope': [sampling scope],
+                                               'type': 'discrete', 'continuous', 'categorical'}, ...}, ...},
+
+            e.g. ``{'operation_name': {'param1': {'hyperopt-dist': hp.uniformint,
+                                                  'sampling-scope': [2, 21]),
+                                                  'type': 'discrete'}, ...}, ..}
     """
 
     def __init__(self, search_space: Dict[str, Dict[str, Dict[str, Union[Callable, List, str]]]]):

--- a/golem/core/tuning/search_space.py
+++ b/golem/core/tuning/search_space.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Callable, List, Union
+from typing import Dict, Callable, List, Union
 
 import numpy as np
 from hyperopt import hp
@@ -8,8 +8,10 @@ class SearchSpace:
     """
     Args:
         search_space: dictionary with parameters and their search_space
-            {'operation_name': {'param_name': (hyperopt distribution function, [sampling scope]), ...}, ...},
-            e.g. ``{'operation_name': {'param1': (hp.uniformint, [2, 21]), ...}, ..}
+            {'operation_name': {'param_name': {'hyperopt-dist': hyperopt distribution function,
+            'sampling-scope': [sampling scope], 'type': 'discrete' or 'continuous'}, ...}, ...},
+            e.g. ``{'operation_name': {'param1': {'hyperopt-dist': hp.uniformint, 'sampling-scope': [2, 21]),
+            'type': 'discrete'}, ...}, ..}
     """
 
     def __init__(self, search_space: Dict[str, Dict[str, Dict[str, Union[Callable, List, str]]]]):
@@ -43,14 +45,15 @@ class SearchSpace:
 
     def get_node_parameters_for_hyperopt(self, node_id, operation_name):
         """
-        Method for forming dictionary with hyperparameters for considering
-        operation as a part of the whole graph
+        Method for forming dictionary with hyperparameters of the node operation for the ``HyperoptTuner``
 
-        :param node_id: number of node in graph.nodes list
-        :param operation_name: name of operation in the node
+        Args:
+            node_id: number of node in graph.nodes list
+            operation_name: name of operation in the node
 
-        :return parameters_dict: dictionary-like structure with labeled hyperparameters
-        and their range per operation
+        Returns:
+            parameters_dict: dictionary-like structure with labeled hyperparameters
+            and their range per operation
         """
 
         # Get available parameters for current operation
@@ -70,6 +73,19 @@ class SearchSpace:
         return parameters_dict
 
     def get_node_parameters_for_iopt(self, node_id, operation_name):
+        """
+        Method for forming dictionary with hyperparameters of node operation for the ``IOptTuner``
+
+        Args:
+            node_id: number of node in graph.nodes list
+            operation_name: name of operation in the node
+
+        Returns:
+            float_parameters_dict: dictionary-like structure with labeled float hyperparameters
+            and their range per operation
+            discrete_parameters_dict: dictionary-like structure with labeled discrete hyperparameters
+            and their range per operation
+        """
         # Get available parameters for operation
         parameters_dict = self.parameters_per_operation.get(operation_name)
 
@@ -83,9 +99,11 @@ class SearchSpace:
 
                 parameter_type = parameter_properties.get('type')
                 if parameter_type == 'discrete':
-                    discrete_parameters_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
+                    discrete_parameters_dict.update({node_op_parameter_name: parameter_properties
+                                                    .get('sampling-scope')})
                 elif parameter_type == 'continuous':
-                    float_parameters_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
+                    float_parameters_dict.update({node_op_parameter_name: parameter_properties
+                                                 .get('sampling-scope')})
 
         return float_parameters_dict, discrete_parameters_dict
 
@@ -107,8 +125,11 @@ def convert_parameters(parameters):
     """
     Function removes labels from dictionary with operations
 
-    :param parameters: labeled parameters
-    :return new_parameters: dictionary without labels of node_id and operation_name
+    Args:
+        parameters: labeled parameters
+
+    Returns:
+        new_parameters: dictionary without labels of node_id and operation_name
     """
 
     new_parameters = {}

--- a/golem/core/tuning/search_space.py
+++ b/golem/core/tuning/search_space.py
@@ -17,41 +17,6 @@ class SearchSpace:
     def __init__(self, search_space: Dict[str, Dict[str, Dict[str, Union[Callable, List, str]]]]):
         self.parameters_per_operation = search_space
 
-    def get_node_parameters_for_iopt(self, node_id, operation_name):
-        """
-        Method for forming dictionary with hyperparameters of node operation for the ``IOptTuner``
-
-        Args:
-            node_id: number of node in graph.nodes list
-            operation_name: name of operation in the node
-
-        Returns:
-            float_parameters_dict: dictionary-like structure with labeled float hyperparameters
-            and their range per operation
-            discrete_parameters_dict: dictionary-like structure with labeled discrete hyperparameters
-            and their range per operation
-        """
-        # Get available parameters for operation
-        parameters_dict = self.parameters_per_operation.get(operation_name)
-
-        discrete_parameters_dict = {}
-        float_parameters_dict = {}
-
-        if parameters_dict is not None:
-
-            for parameter_name, parameter_properties in parameters_dict.items():
-                node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
-
-                parameter_type = parameter_properties.get('type')
-                if parameter_type == 'discrete':
-                    discrete_parameters_dict.update({node_op_parameter_name: parameter_properties
-                                                    .get('sampling-scope')})
-                elif parameter_type == 'continuous':
-                    float_parameters_dict.update({node_op_parameter_name: parameter_properties
-                                                 .get('sampling-scope')})
-
-        return float_parameters_dict, discrete_parameters_dict
-
     def get_parameters_for_operation(self, operation_name: str) -> List[str]:
         parameters_list = list(self.parameters_per_operation.get(operation_name, {}).keys())
         return parameters_list

--- a/golem/core/tuning/search_space.py
+++ b/golem/core/tuning/search_space.py
@@ -41,7 +41,7 @@ class SearchSpace:
         else:
             return None
 
-    def get_node_params_for_hyperopt(self, node_id, operation_name):
+    def get_node_parameters_for_hyperopt(self, node_id, operation_name):
         """
         Method for forming dictionary with hyperparameters for considering
         operation as a part of the whole graph
@@ -49,15 +49,15 @@ class SearchSpace:
         :param node_id: number of node in graph.nodes list
         :param operation_name: name of operation in the node
 
-        :return params_dict: dictionary-like structure with labeled hyperparameters
+        :return parameters_dict: dictionary-like structure with labeled hyperparameters
         and their range per operation
         """
 
         # Get available parameters for current operation
-        params_list = self.get_parameters_for_operation(operation_name)
+        parameters_list = self.get_parameters_for_operation(operation_name)
 
-        params_dict = {}
-        for parameter_name in params_list:
+        parameters_dict = {}
+        for parameter_name in parameters_list:
             node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
 
             # For operation get range where search can be done
@@ -65,33 +65,33 @@ class SearchSpace:
                                                       parameter_name=parameter_name,
                                                       label=node_op_parameter_name)
 
-            params_dict.update({node_op_parameter_name: space})
+            parameters_dict.update({node_op_parameter_name: space})
 
-        return params_dict
+        return parameters_dict
 
-    def get_node_params_for_iopt(self, node_id, operation_name):
+    def get_node_parameters_for_iopt(self, node_id, operation_name):
         # Get available parameters for operation
-        params_dict = self.parameters_per_operation.get(operation_name)
+        parameters_dict = self.parameters_per_operation.get(operation_name)
 
-        discrete_params_dict = {}
-        float_params_dict = {}
+        discrete_parameters_dict = {}
+        float_parameters_dict = {}
 
-        if params_dict is not None:
+        if parameters_dict is not None:
 
-            for parameter_name, parameter_properties in params_dict.items():
+            for parameter_name, parameter_properties in parameters_dict.items():
                 node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
 
                 parameter_type = parameter_properties.get('type')
                 if parameter_type == 'discrete':
-                    discrete_params_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
+                    discrete_parameters_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
                 elif parameter_type == 'continuous':
-                    float_params_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
+                    float_parameters_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
 
-        return float_params_dict, discrete_params_dict
+        return float_parameters_dict, discrete_parameters_dict
 
     def get_parameters_for_operation(self, operation_name: str) -> List[str]:
-        params_list = list(self.parameters_per_operation.get(operation_name, {}).keys())
-        return params_list
+        parameters_list = list(self.parameters_per_operation.get(operation_name, {}).keys())
+        return parameters_list
 
 
 def get_node_operation_parameter_label(node_id: int, operation_name: str, parameter_name: str) -> str:
@@ -103,20 +103,20 @@ def get_node_operation_parameter_label(node_id: int, operation_name: str, parame
     return node_op_parameter_name
 
 
-def convert_params(params):
+def convert_parameters(parameters):
     """
     Function removes labels from dictionary with operations
 
-    :param params: labeled parameters
-    :return new_params: dictionary without labels of node_id and operation_name
+    :param parameters: labeled parameters
+    :return new_parameters: dictionary without labels of node_id and operation_name
     """
 
-    new_params = {}
-    for operation_parameter, value in params.items():
+    new_parameters = {}
+    for operation_parameter, value in parameters.items():
         # Remove right part of the parameter name
         parameter_name = operation_parameter.split(' | ')[-1]
 
         if value is not None:
-            new_params.update({parameter_name: value})
+            new_parameters.update({parameter_name: value})
 
-    return new_params
+    return new_parameters

--- a/golem/core/tuning/search_space.py
+++ b/golem/core/tuning/search_space.py
@@ -1,7 +1,6 @@
 from typing import Dict, Callable, List, Union
 
-import numpy as np
-from hyperopt import hp
+OperationParametersMapping = Dict[str, Dict[str, Dict[str, Union[Callable, List, str]]]]
 
 
 class SearchSpace:
@@ -10,14 +9,20 @@ class SearchSpace:
         search_space: dictionary with parameters and their search_space
             {'operation_name': {'param_name': {'hyperopt-dist': hyperopt distribution function,
                                                'sampling-scope': [sampling scope],
-                                               'type': 'discrete', 'continuous', 'categorical'}, ...}, ...},
+                                               'type': 'discrete', 'continuous' or 'categorical'}, ...}, ...},
 
             e.g. ``{'operation_name': {'param1': {'hyperopt-dist': hp.uniformint,
                                                   'sampling-scope': [2, 21]),
-                                                  'type': 'discrete'}, ...}, ..}
+                                                  'type': 'discrete'},
+                                       'param2': {'hyperopt-dist': hp.loguniform,
+                                                  'sampling-scope': [0.001, 1]),
+                                                  'type': 'continuous'},
+                                       'param3': {'hyperopt-dist': hp.choice,
+                                                  'sampling-scope': [['svd', 'lsqr', 'eigen']),
+                                                  'type': 'categorical'}...}, ..}
     """
 
-    def __init__(self, search_space: Dict[str, Dict[str, Dict[str, Union[Callable, List, str]]]]):
+    def __init__(self, search_space: OperationParametersMapping):
         self.parameters_per_operation = search_space
 
     def get_parameters_for_operation(self, operation_name: str) -> List[str]:

--- a/golem/core/tuning/search_space.py
+++ b/golem/core/tuning/search_space.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Callable, List
+from typing import Dict, Tuple, Callable, List, Union
 
 import numpy as np
 from hyperopt import hp
@@ -12,7 +12,7 @@ class SearchSpace:
             e.g. ``{'operation_name': {'param1': (hp.uniformint, [2, 21]), ...}, ..}
     """
 
-    def __init__(self, search_space: Dict[str, Dict[str, Tuple[Callable, List]]]):
+    def __init__(self, search_space: Dict[str, Dict[str, Dict[str, Union[Callable, List, str]]]]):
         self.parameters_per_operation = search_space
 
     def get_parameter_hyperopt_space(self, operation_name: str, parameter_name: str, label: str = 'default'):
@@ -33,8 +33,8 @@ class SearchSpace:
 
         if operation_parameters is not None:
             parameter_properties = operation_parameters.get(parameter_name)
-            hyperopt_distribution = parameter_properties.get('hyperopt_dist')
-            sampling_scope = parameter_properties.get('sampling_scope')
+            hyperopt_distribution = parameter_properties.get('hyperopt-dist')
+            sampling_scope = parameter_properties.get('sampling-scope')
             if hyperopt_distribution == hp.loguniform:
                 sampling_scope = [np.log(x) for x in sampling_scope]
             return hyperopt_distribution(label, *sampling_scope)
@@ -81,16 +81,16 @@ class SearchSpace:
             for parameter_name, parameter_properties in params_dict.items():
                 node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
 
-                parameter_type = parameter_properties.get(type)
+                parameter_type = parameter_properties.get('type')
                 if parameter_type == 'discrete':
-                    discrete_params_dict.update({node_op_parameter_name, parameter_properties.get('sampling_scope')})
+                    discrete_params_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
                 elif parameter_type == 'continuous':
-                    float_params_dict.update({node_op_parameter_name, parameter_properties.get('sampling_scope')})
+                    float_params_dict.update({node_op_parameter_name: parameter_properties.get('sampling-scope')})
 
         return float_params_dict, discrete_params_dict
 
     def get_parameters_for_operation(self, operation_name: str) -> List[str]:
-        params_list = list(self.parameters_per_operation.get(operation_name).keys())
+        params_list = list(self.parameters_per_operation.get(operation_name, {}).keys())
         return params_list
 
 

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -7,7 +7,7 @@ from hyperopt import tpe, fmin, space_eval
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.objective import ObjectiveEvaluate
-from golem.core.tuning.search_space import SearchSpace, convert_parameters
+from golem.core.tuning.search_space import SearchSpace
 from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune
 
 

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -26,8 +26,14 @@ class SequentialTuner(HyperoptTuner):
                  deviation: float = 0.05,
                  algo: Callable = tpe.suggest,
                  inverse_node_order: bool = False):
-        super().__init__(objective_evaluate, search_space, adapter, iterations, early_stopping_rounds, timeout, n_jobs,
-                         deviation, algo)
+        super().__init__(objective_evaluate,
+                         search_space,
+                         adapter,
+                         iterations,
+                         early_stopping_rounds, timeout,
+                         n_jobs,
+                         deviation,
+                         algo)
 
         self.inverse_node_order = inverse_node_order
 
@@ -137,7 +143,10 @@ class SequentialTuner(HyperoptTuner):
         final_graph = self.adapter.restore(final_graph)
         return final_graph
 
-    def _optimize_node(self, graph: OptGraph, node_id: int, node_params: dict, iterations_per_node: int,
+    def _optimize_node(self, graph: OptGraph,
+                       node_id: int,
+                       node_params: dict,
+                       iterations_per_node: int,
                        seconds_per_node: int) -> OptGraph:
         """
         Method for node optimization

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -26,9 +26,15 @@ class SequentialTuner(HyperoptTuner):
                  deviation: float = 0.05,
                  algo: Callable = tpe.suggest,
                  inverse_node_order=False):
-        super().__init__(objective_evaluate=objective_evaluate, search_space=search_space, adapter=adapter,
-                         iterations=iterations, early_stopping_rounds=early_stopping_rounds,
-                         timeout=timeout, n_jobs=n_jobs, deviation=deviation, algo=algo)
+        super().__init__(objective_evaluate,
+                         search_space,
+                         adapter,
+                         iterations,
+                         early_stopping_rounds,
+                         timeout,
+                         n_jobs,
+                         deviation,
+                         algo)
 
         self.inverse_node_order = inverse_node_order
 
@@ -117,7 +123,8 @@ class SequentialTuner(HyperoptTuner):
         operation_name = node.name
 
         # Get node's parameters to optimize
-        node_params = get_node_parameters_for_hyperopt(self.search_space, node_id=node_index,
+        node_params = get_node_parameters_for_hyperopt(self.search_space,
+                                                       node_id=node_index,
                                                        operation_name=operation_name)
 
         if not node_params:

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -187,24 +187,3 @@ class SequentialTuner(HyperoptTuner):
 
         metric_value = self.get_metric_value(graph=graph)
         return metric_value
-
-    @staticmethod
-    def set_arg_node(graph: OptGraph, node_id: int, node_params: dict) -> OptGraph:
-        """ Method for parameters setting to a graph
-
-        Args:
-            graph: graph which contains the node
-            node_id: id of the node to which parameters should be assigned
-            node_params: dictionary with labeled parameters to set
-
-        Returns:
-            graph with new hyperparameters in each node
-        """
-
-        # Remove label prefixes
-        node_params = convert_params(node_params)
-
-        # Update parameters in nodes
-        graph.nodes[node_id].parameters = node_params
-
-        return graph

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -19,13 +19,13 @@ class SequentialTuner(HyperoptTuner):
     def __init__(self, objective_evaluate: ObjectiveEvaluate,
                  search_space: SearchSpace,
                  adapter: Optional[BaseOptimizationAdapter] = None,
-                 iterations=100,
-                 early_stopping_rounds=None,
+                 iterations: int = 100,
+                 early_stopping_rounds: Optional[int] = None,
                  timeout: timedelta = timedelta(minutes=5),
                  n_jobs: int = -1,
                  deviation: float = 0.05,
                  algo: Callable = tpe.suggest,
-                 inverse_node_order=False):
+                 inverse_node_order: bool = False):
         super().__init__(objective_evaluate,
                          search_space,
                          adapter,

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -26,15 +26,8 @@ class SequentialTuner(HyperoptTuner):
                  deviation: float = 0.05,
                  algo: Callable = tpe.suggest,
                  inverse_node_order: bool = False):
-        super().__init__(objective_evaluate,
-                         search_space,
-                         adapter,
-                         iterations,
-                         early_stopping_rounds,
-                         timeout,
-                         n_jobs,
-                         deviation,
-                         algo)
+        super().__init__(objective_evaluate, search_space, adapter, iterations, early_stopping_rounds, timeout, n_jobs,
+                         deviation, algo)
 
         self.inverse_node_order = inverse_node_order
 

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -61,10 +61,10 @@ class SequentialTuner(HyperoptTuner):
             operation_name = node.name
 
             # Get node's parameters to optimize
-            node_params = self.search_space.get_node_params(node_id=node_id,
-                                                            operation_name=operation_name)
+            node_params = self.search_space.get_node_params_for_hyperopt(node_id=node_id,
+                                                                         operation_name=operation_name)
 
-            if node_params is None:
+            if not node_params:
                 self.log.info(f'"{operation_name}" operation has no parameters to optimize')
             else:
                 # Apply tuning for current node
@@ -115,10 +115,10 @@ class SequentialTuner(HyperoptTuner):
         operation_name = node.name
 
         # Get node's parameters to optimize
-        node_params = self.search_space.get_node_params(node_id=node_index,
-                                                        operation_name=operation_name)
+        node_params = self.search_space.get_node_params_for_hyperopt(node_id=node_index,
+                                                                     operation_name=operation_name)
 
-        if node_params is None:
+        if not node_params:
             self._stop_tuning_with_message(f'"{operation_name}" operation has no parameters to optimize')
         else:
             # Apply tuning for current node

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -161,23 +161,17 @@ class SequentialTuner(HyperoptTuner):
         Returns:
             updated graph with tuned parameters in particular node
         """
-        best_parameters = fmin(partial(self._objective,
-                                       graph=graph,
-                                       node_id=node_id
-                                       ),
+        best_parameters = fmin(partial(self._objective, graph=graph, node_id=node_id),
                                node_params,
                                algo=self.algo,
                                max_evals=iterations_per_node,
                                early_stop_fn=self.early_stop_fn,
                                timeout=seconds_per_node)
 
-        best_parameters = space_eval(space=node_params,
-                                     hp_assignment=best_parameters)
+        best_parameters = space_eval(space=node_params, hp_assignment=best_parameters)
 
         # Set best params for this node in the graph
-        graph = self.set_arg_node(graph=graph,
-                                  node_id=node_id,
-                                  node_params=best_parameters)
+        graph = self.set_arg_node(graph=graph, node_id=node_id, node_params=best_parameters)
         return graph
 
     def _objective(self, node_params: dict, graph: OptGraph, node_id: int) -> float:
@@ -193,8 +187,7 @@ class SequentialTuner(HyperoptTuner):
         """
 
         # Set hyperparameters for node
-        graph = self.set_arg_node(graph=graph, node_id=node_id,
-                                  node_params=node_params)
+        graph = self.set_arg_node(graph=graph, node_id=node_id, node_params=node_params)
 
         metric_value = self.get_metric_value(graph=graph)
         return metric_value

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -8,7 +8,8 @@ from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.objective import ObjectiveFunction
 from golem.core.tuning.search_space import SearchSpace
-from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune, get_node_parameters_for_hyperopt
+from golem.core.tuning.tuner_interface import DomainGraphForTune
+from golem.core.tuning.hyperopt_tuner import HyperoptTuner, get_node_parameters_for_hyperopt
 
 
 class SequentialTuner(HyperoptTuner):

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -6,7 +6,7 @@ from hyperopt import tpe, fmin, space_eval
 
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph
-from golem.core.optimisers.objective import ObjectiveEvaluate
+from golem.core.optimisers.objective import ObjectiveFunction
 from golem.core.tuning.search_space import SearchSpace
 from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune, get_node_parameters_for_hyperopt
 
@@ -16,7 +16,7 @@ class SequentialTuner(HyperoptTuner):
     Class for hyperparameters optimization for all nodes sequentially
     """
 
-    def __init__(self, objective_evaluate: ObjectiveEvaluate,
+    def __init__(self, objective_evaluate: ObjectiveFunction,
                  search_space: SearchSpace,
                  adapter: Optional[BaseOptimizationAdapter] = None,
                  iterations: int = 100,

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -7,7 +7,7 @@ from hyperopt import tpe, fmin, space_eval
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.objective import ObjectiveEvaluate
-from golem.core.tuning.search_space import SearchSpace, convert_params
+from golem.core.tuning.search_space import SearchSpace, convert_parameters
 from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune
 
 
@@ -61,8 +61,8 @@ class SequentialTuner(HyperoptTuner):
             operation_name = node.name
 
             # Get node's parameters to optimize
-            node_params = self.search_space.get_node_params_for_hyperopt(node_id=node_id,
-                                                                         operation_name=operation_name)
+            node_params = self.search_space.get_node_parameters_for_hyperopt(node_id=node_id,
+                                                                             operation_name=operation_name)
 
             if not node_params:
                 self.log.info(f'"{operation_name}" operation has no parameters to optimize')
@@ -115,8 +115,8 @@ class SequentialTuner(HyperoptTuner):
         operation_name = node.name
 
         # Get node's parameters to optimize
-        node_params = self.search_space.get_node_params_for_hyperopt(node_id=node_index,
-                                                                     operation_name=operation_name)
+        node_params = self.search_space.get_node_parameters_for_hyperopt(node_id=node_index,
+                                                                         operation_name=operation_name)
 
         if not node_params:
             self._stop_tuning_with_message(f'"{operation_name}" operation has no parameters to optimize')

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -30,17 +30,15 @@ class SimultaneousTuner(HyperoptTuner):
         graph = self.adapter.adapt(graph)
         parameters_dict, init_parameters = self._get_parameters_for_tune(graph)
 
+        if not parameters_dict:
+            self._stop_tuning_with_message(f'Graph "{graph.graph_description}" has no parameters to optimize')
+
         with Timer() as global_tuner_timer:
             self.init_check(graph)
-
             self._update_remaining_time(global_tuner_timer)
 
             if self.max_seconds <= MIN_TIME_FOR_TUNING_IN_SEC:
                 self._stop_tuning_with_message('Tunner stopped after initial assumption due to the lack of time')
-
-            elif not parameters_dict:
-                self._stop_tuning_with_message(f'Graph "{graph.graph_description}" has no parameters to optimize')
-
             else:
 
                 trials = Trials()

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -71,8 +71,7 @@ class SimultaneousTuner(HyperoptTuner):
                     if is_best_trial_with_init_params:
                         best = {**best, **init_parameters}
 
-                    tuned_graph = self.set_arg_graph(graph=graph,
-                                                     parameters=best)
+                    tuned_graph = self.set_arg_graph(graph=graph, parameters=best)
 
                     # Validation is the optimization do well
                     graph = self.final_check(tuned_graph)

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -147,7 +147,7 @@ class SimultaneousTuner(HyperoptTuner):
             tunable_node_params = self.search_space.get_parameters_for_operation(operation_name)
             if tunable_node_params:
                 tunable_initial_params = {get_node_operation_parameter_label(node_id, operation_name, p):
-                                              node.parameters[p] for p in node.parameters if p in tunable_node_params}
+                                          node.parameters[p] for p in node.parameters if p in tunable_node_params}
                 if tunable_initial_params:
                     initial_parameters.update(tunable_initial_params)
 

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -7,7 +7,8 @@ from golem.core.constants import MIN_TIME_FOR_TUNING_IN_SEC
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.timer import Timer
 from golem.core.tuning.search_space import get_node_operation_parameter_label
-from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune, get_node_parameters_for_hyperopt
+from golem.core.tuning.tuner_interface import DomainGraphForTune
+from golem.core.tuning.hyperopt_tuner import HyperoptTuner, get_node_parameters_for_hyperopt
 
 
 class SimultaneousTuner(HyperoptTuner):

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -6,7 +6,7 @@ from hyperopt import Trials, fmin, space_eval
 from golem.core.constants import MIN_TIME_FOR_TUNING_IN_SEC
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.timer import Timer
-from golem.core.tuning.search_space import get_node_operation_parameter_label, convert_params
+from golem.core.tuning.search_space import get_node_operation_parameter_label
 from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune
 
 
@@ -14,6 +14,7 @@ class SimultaneousTuner(HyperoptTuner):
     """
         Class for hyperparameters optimization for all nodes simultaneously
     """
+
     def tune(self, graph: DomainGraphForTune, show_progress: bool = True) -> DomainGraphForTune:
         """ Function for hyperparameters tuning on the entire graph
 
@@ -139,13 +140,11 @@ class SimultaneousTuner(HyperoptTuner):
 
             # Assign unique prefix for each model hyperparameter
             # label - number of node in the graph
-            node_params = self.search_space.get_node_params(node_id=node_id,
-                                                            operation_name=operation_name)
+            node_params = self.search_space.get_node_params_for_hyperopt(node_id=node_id,
+                                                                         operation_name=operation_name)
+            parameters_dict.update(node_params)
 
-            if node_params is not None:
-                parameters_dict.update(node_params)
-
-            tunable_node_params = self.search_space.get_operation_parameter_range(operation_name)
+            tunable_node_params = self.search_space.get_parameters_for_operation(operation_name)
             if tunable_node_params:
                 tunable_initial_params = {get_node_operation_parameter_label(node_id, operation_name, p):
                                               node.parameters[p] for p in node.parameters if p in tunable_node_params}
@@ -178,4 +177,3 @@ class SimultaneousTuner(HyperoptTuner):
         metric_value = self.get_metric_value(graph=graph)
 
         return metric_value
-

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -7,7 +7,7 @@ from golem.core.constants import MIN_TIME_FOR_TUNING_IN_SEC
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.timer import Timer
 from golem.core.tuning.search_space import get_node_operation_parameter_label
-from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune
+from golem.core.tuning.tuner_interface import HyperoptTuner, DomainGraphForTune, get_node_parameters_for_hyperopt
 
 
 class SimultaneousTuner(HyperoptTuner):
@@ -140,14 +140,14 @@ class SimultaneousTuner(HyperoptTuner):
 
             # Assign unique prefix for each model hyperparameter
             # label - number of node in the graph
-            node_params = self.search_space.get_node_parameters_for_hyperopt(node_id=node_id,
-                                                                             operation_name=operation_name)
+            node_params = get_node_parameters_for_hyperopt(self.search_space, node_id=node_id,
+                                                           operation_name=operation_name)
             parameters_dict.update(node_params)
 
             tunable_node_params = self.search_space.get_parameters_for_operation(operation_name)
             if tunable_node_params:
                 tunable_initial_params = {get_node_operation_parameter_label(node_id, operation_name, p):
-                                          node.parameters[p] for p in node.parameters if p in tunable_node_params}
+                                              node.parameters[p] for p in node.parameters if p in tunable_node_params}
                 if tunable_initial_params:
                     initial_parameters.update(tunable_initial_params)
 

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -47,9 +47,11 @@ class SimultaneousTuner(HyperoptTuner):
                 try:
                     # try searching using initial parameters
                     # (uses original search space with fixed initial parameters)
-                    trials, init_trials_num = self._search_near_initial_parameters(graph, parameters_dict,
+                    trials, init_trials_num = self._search_near_initial_parameters(graph,
+                                                                                   parameters_dict,
                                                                                    init_parameters,
-                                                                                   trials, show_progress)
+                                                                                   trials,
+                                                                                   show_progress)
                     self._update_remaining_time(global_tuner_timer)
                     if self.max_seconds > MIN_TIME_FOR_TUNING_IN_SEC:
                         best = fmin(partial(self._objective, graph=graph),

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -84,8 +84,11 @@ class SimultaneousTuner(HyperoptTuner):
 
         return final_graph
 
-    def _search_near_initial_parameters(self, graph: OptGraph, search_space: dict, initial_parameters: dict,
-                                        trials: Trials, show_progress: bool = True) -> Tuple[Trials, int]:
+    def _search_near_initial_parameters(self, graph: OptGraph,
+                                        search_space: dict,
+                                        initial_parameters: dict,
+                                        trials: Trials,
+                                        show_progress: bool = True) -> Tuple[Trials, int]:
         """ Method to search using the search space where parameters initially set for the graph are fixed.
         This allows not to lose results obtained while composition process
 

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -179,27 +179,3 @@ class SimultaneousTuner(HyperoptTuner):
 
         return metric_value
 
-    @staticmethod
-    def set_arg_graph(graph: OptGraph, parameters: dict) -> OptGraph:
-        """ Method for parameters setting to a graph
-
-        Args:
-            graph: graph to which parameters should be assigned
-            parameters: dictionary with parameters to set
-
-        Returns:
-            graph: graph with new hyperparameters in each node
-        """
-        # Set hyperparameters for every node
-        for node_id, node in enumerate(graph.nodes):
-            node_params = {key: value for key, value in parameters.items()
-                           if key.startswith(f'{str(node_id)} || {node.name}')}
-
-            if node_params is not None:
-                # Delete all prefix strings to get appropriate parameters names
-                new_params = convert_params(node_params)
-
-                # Update parameters in nodes
-                graph.nodes[node_id].parameters = new_params
-
-        return graph

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -151,7 +151,7 @@ class SimultaneousTuner(HyperoptTuner):
             tunable_node_params = self.search_space.get_parameters_for_operation(operation_name)
             if tunable_node_params:
                 tunable_initial_params = {get_node_operation_parameter_label(node_id, operation_name, p):
-                                              node.parameters[p] for p in node.parameters if p in tunable_node_params}
+                                          node.parameters[p] for p in node.parameters if p in tunable_node_params}
                 if tunable_initial_params:
                     initial_parameters.update(tunable_initial_params)
 

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -140,8 +140,8 @@ class SimultaneousTuner(HyperoptTuner):
 
             # Assign unique prefix for each model hyperparameter
             # label - number of node in the graph
-            node_params = self.search_space.get_node_params_for_hyperopt(node_id=node_id,
-                                                                         operation_name=operation_name)
+            node_params = self.search_space.get_node_parameters_for_hyperopt(node_id=node_id,
+                                                                             operation_name=operation_name)
             parameters_dict.update(node_params)
 
             tunable_node_params = self.search_space.get_parameters_for_operation(operation_name)

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -189,9 +189,8 @@ class BaseTuner(Generic[DomainGraphForTune]):
 
 
 class HyperoptTuner(BaseTuner, ABC):
-    """
-    Base class for hyperparameters optimization based on hyperopt library
-    
+    """Base class for hyperparameters optimization based on hyperopt library
+
     Args:
       objective_evaluate: objective to optimize
       adapter: the function for processing of external object that should be optimized

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -94,6 +94,10 @@ class BaseTuner(Generic[DomainGraphForTune]):
 
         return graph
 
+    def _stop_tuning_with_message(self, message: str):
+        self.log.message(message)
+        self.obtained_metric = self.init_metric
+
 
 class HyperoptTuner(BaseTuner, ABC):
     """
@@ -201,10 +205,6 @@ class HyperoptTuner(BaseTuner, ABC):
         if not graph_fitness.valid:
             return self._default_metric_value
         return metric_value
-
-    def _stop_tuning_with_message(self, message: str):
-        self.log.message(message)
-        self.obtained_metric = self.init_metric
 
     def _update_remaining_time(self, tuner_timer: Timer):
         self.max_seconds = self.max_seconds - tuner_timer.minutes_from_start * 60

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from typing import Callable, TypeVar, Generic, Optional
 
 import numpy as np
-from hyperopt import hp
+from hyperopt import hp, tpe
 from hyperopt.early_stop import no_progress_loss
 
 from golem.core.adapter import BaseOptimizationAdapter
@@ -48,7 +48,7 @@ class BaseTuner(Generic[DomainGraphForTune]):
         self.search_space = search_space
         self.n_jobs = n_jobs
         objective_evaluate.eval_n_jobs = self.n_jobs
-        self.objective_evaluate = self.adapter.adapt_func(objective_evaluate.evaluate)
+        self.objective_evaluate = self.adapter.adapt_func(objective_evaluate)
         self.deviation = deviation
 
         self.timeout = timeout
@@ -219,14 +219,14 @@ class HyperoptTuner(BaseTuner, ABC):
                  timeout: timedelta = timedelta(minutes=5),
                  n_jobs: int = -1,
                  deviation: float = 0.05,
-                 algo: Callable = None):
+                 algo: Callable = tpe.suggest):
         early_stopping_rounds = early_stopping_rounds or max(100, int(np.sqrt(iterations) * 10))
         super().__init__(objective_evaluate,
                          search_space,
                          adapter,
                          iterations,
-                         timeout,
                          early_stopping_rounds,
+                         timeout,
                          n_jobs,
                          deviation)
 

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -1,12 +1,9 @@
-from abc import abstractmethod, ABC
+from abc import abstractmethod
 from copy import deepcopy
 from datetime import timedelta
-from typing import Callable, TypeVar, Generic, Optional, Dict
+from typing import TypeVar, Generic, Optional
 
 import numpy as np
-from hyperopt import hp, tpe
-from hyperopt.early_stop import no_progress_loss
-from hyperopt.pyll import Apply
 
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.adapter.adapter import IdentityAdapter
@@ -15,8 +12,7 @@ from golem.core.dag.graph_utils import graph_structure
 from golem.core.log import default_log
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.objective import ObjectiveEvaluate, ObjectiveFunction
-from golem.core.optimisers.timer import Timer
-from golem.core.tuning.search_space import SearchSpace, convert_parameters, get_node_operation_parameter_label
+from golem.core.tuning.search_space import SearchSpace, convert_parameters
 
 DomainGraphForTune = TypeVar('DomainGraphForTune')
 
@@ -197,110 +193,3 @@ class BaseTuner(Generic[DomainGraphForTune]):
     def _stop_tuning_with_message(self, message: str):
         self.log.message(message)
         self.obtained_metric = self.init_metric
-
-
-class HyperoptTuner(BaseTuner, ABC):
-    """Base class for hyperparameters optimization based on hyperopt library
-
-    Args:
-      objective_evaluate: objective to optimize
-      adapter: the function for processing of external object that should be optimized
-      search_space: SearchSpace instance
-      iterations: max number of iterations
-      early_stopping_rounds: Optional max number of stagnating iterations for early stopping. If ``None``, will be set
-          to ``max(100, int(np.sqrt(iterations) * 10))``.
-      timeout: max time for tuning
-      n_jobs: num of ``n_jobs`` for parallelization (``-1`` for use all cpu's)
-      deviation: required improvement (in percent) of a metric to return tuned graph.
-        By default, ``deviation=0.05``, which means that tuned graph will be returned
-        if it's metric will be at least 0.05% better than the initial.
-      algo: algorithm for hyperparameters optimization with signature similar to :obj:`hyperopt.tse.suggest`
-    """
-
-    def __init__(self, objective_evaluate: ObjectiveFunction,
-                 search_space: SearchSpace,
-                 adapter: Optional[BaseOptimizationAdapter] = None,
-                 iterations: int = 100,
-                 early_stopping_rounds: Optional[int] = None,
-                 timeout: timedelta = timedelta(minutes=5),
-                 n_jobs: int = -1,
-                 deviation: float = 0.05,
-                 algo: Callable = tpe.suggest):
-        early_stopping_rounds = early_stopping_rounds or max(100, int(np.sqrt(iterations) * 10))
-        super().__init__(objective_evaluate,
-                         search_space,
-                         adapter,
-                         iterations,
-                         early_stopping_rounds,
-                         timeout,
-                         n_jobs,
-                         deviation)
-
-        self.early_stop_fn = no_progress_loss(iteration_stop_count=self.early_stopping_rounds)
-        self.max_seconds = int(timeout.seconds) if timeout is not None else None
-        self.algo = algo
-        self.log = default_log(self)
-
-    def _update_remaining_time(self, tuner_timer: Timer):
-        self.max_seconds = self.max_seconds - tuner_timer.minutes_from_start * 60
-
-
-def get_parameter_hyperopt_space(search_space: SearchSpace,
-                                 operation_name: str,
-                                 parameter_name: str,
-                                 label: str = 'default') -> Optional[Apply]:
-    """
-    Function return hyperopt object with search_space from search_space dictionary
-
-    Args:
-        search_space: SearchSpace with parameters per operation
-        operation_name: name of the operation
-        parameter_name: name of hyperparameter of particular operation
-        label: label to assign in hyperopt pyll
-
-    Returns:
-        parameter range
-    """
-
-    # Get available parameters for current operation
-    operation_parameters = search_space.parameters_per_operation.get(operation_name)
-
-    if operation_parameters is not None:
-        parameter_properties = operation_parameters.get(parameter_name)
-        hyperopt_distribution = parameter_properties.get('hyperopt-dist')
-        sampling_scope = parameter_properties.get('sampling-scope')
-        if hyperopt_distribution == hp.loguniform:
-            sampling_scope = [np.log(x) for x in sampling_scope]
-        return hyperopt_distribution(label, *sampling_scope)
-    else:
-        return None
-
-
-def get_node_parameters_for_hyperopt(search_space: SearchSpace, node_id: int, operation_name: str) \
-        -> Dict[str, Apply]:
-    """
-    Function for forming dictionary with hyperparameters of the node operation for the ``HyperoptTuner``
-
-    Args:
-        search_space: SearchSpace with parameters per operation
-        node_id: number of node in graph.nodes list
-        operation_name: name of operation in the node
-
-    Returns:
-        parameters_dict: dictionary-like structure with labeled hyperparameters
-        and their range per operation
-    """
-
-    # Get available parameters for current operation
-    parameters_list = search_space.get_parameters_for_operation(operation_name)
-
-    parameters_dict = {}
-    for parameter_name in parameters_list:
-        node_op_parameter_name = get_node_operation_parameter_label(node_id, operation_name, parameter_name)
-
-        # For operation get range where search can be done
-        space = get_parameter_hyperopt_space(search_space, operation_name, parameter_name, node_op_parameter_name)
-
-        parameters_dict.update({node_op_parameter_name: space})
-
-    return parameters_dict

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -217,7 +217,7 @@ class HyperoptTuner(BaseTuner, ABC):
       algo: algorithm for hyperparameters optimization with signature similar to :obj:`hyperopt.tse.suggest`
     """
 
-    def __init__(self, objective_evaluate: ObjectiveEvaluate,
+    def __init__(self, objective_evaluate: ObjectiveFunction,
                  search_space: SearchSpace,
                  adapter: Optional[BaseOptimizationAdapter] = None,
                  iterations: int = 100,

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -214,15 +214,21 @@ class HyperoptTuner(BaseTuner, ABC):
     def __init__(self, objective_evaluate: ObjectiveEvaluate,
                  search_space: SearchSpace,
                  adapter: BaseOptimizationAdapter = None,
-                 iterations: int = 100, early_stopping_rounds=None,
+                 iterations: int = 100,
+                 early_stopping_rounds=None,
                  timeout: timedelta = timedelta(minutes=5),
                  n_jobs: int = -1,
                  deviation: float = 0.05,
                  algo: Callable = None):
         early_stopping_rounds = early_stopping_rounds or max(100, int(np.sqrt(iterations) * 10))
-        super().__init__(objective_evaluate=objective_evaluate, search_space=search_space, adapter=adapter,
-                         iterations=iterations, timeout=timeout, early_stopping_rounds=early_stopping_rounds,
-                         n_jobs=n_jobs, deviation=deviation)
+        super().__init__(objective_evaluate,
+                         search_space,
+                         adapter,
+                         iterations,
+                         timeout,
+                         early_stopping_rounds,
+                         n_jobs,
+                         deviation)
 
         self.early_stop_fn = no_progress_loss(iteration_stop_count=self.early_stopping_rounds)
         self.max_seconds = int(timeout.seconds) if timeout is not None else None

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -20,6 +20,19 @@ DomainGraphForTune = TypeVar('DomainGraphForTune')
 
 
 class BaseTuner(Generic[DomainGraphForTune]):
+    """
+    Base class for hyperparameters optimization
+
+    Args:
+      objective_evaluate: objective to optimize
+      adapter: the function for processing of external object that should be optimized
+      iterations: max number of iterations
+      search_space: SearchSpace instance
+      n_jobs: num of ``n_jobs`` for parallelization (``-1`` for use all cpu's)
+      deviation: required improvement (in percent) of a metric to return tuned graph.
+        By default, ``deviation=0.05``, which means that tuned graph will be returned
+        if it's metric will be at least 0.05% better than the initial.
+    """
     def __init__(self, objective_evaluate: ObjectiveEvaluate,
                  search_space: SearchSpace,
                  adapter: BaseOptimizationAdapter = None,

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -122,7 +122,7 @@ class BaseTuner(Generic[DomainGraphForTune]):
         if final_metric is not None:
             self.log.message(f'Final metric: {abs(final_metric):.3f}')
         else:
-            self.log.message(f'Final metric is None')
+            self.log.message('Final metric is None')
         return final_graph
 
     def get_metric_value(self, graph: OptGraph) -> float:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ psutil>=5.9.2
 
 # Optimisation
 hyperopt>=0.2.7
-iOpt
+iOpt==0.1.6
 
 # Tests
 pytest>=6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ psutil>=5.9.2
 
 # Optimisation
 hyperopt>=0.2.7
+iOpt
 
 # Tests
 pytest>=6.2.0

--- a/test/unit/tuning/test_tuning.py
+++ b/test/unit/tuning/test_tuning.py
@@ -109,4 +109,3 @@ def test_node_tuning(search_space, graph):
         final_metric = obj_eval.evaluate(tuned_graph)
         assert final_metric is not None
         assert init_metric <= final_metric
-

--- a/test/unit/tuning/test_tuning.py
+++ b/test/unit/tuning/test_tuning.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 
-import numpy as np
 import pytest
 from hyperopt import hp
 
 from golem.core.optimisers.objective import Objective, ObjectiveEvaluate
+from golem.core.tuning.iopt_tuner import IOptTuner
 from golem.core.tuning.search_space import SearchSpace
 from golem.core.tuning.sequential import SequentialTuner
 from golem.core.tuning.simultaneous import SimultaneousTuner
@@ -25,24 +25,52 @@ def not_tunable_mock_graph():
 def search_space():
     params_per_operation = {
         'a': {
-            'a1': (hp.uniformint, [2, 7]),
-            'a2': (hp.loguniform, [np.log(1e-3), np.log(1)])
+            'a1': {
+                'hyperopt-dist': hp.uniformint,
+                'sampling-scope': [2, 7],
+                'type': 'discrete'
+            },
+            'a2': {
+                'hyperopt-dist': hp.loguniform,
+                'sampling-scope': [1e-3, 1],
+                'type': 'continuous'
+            }
         },
         'b': {
-            'b1': (hp.choice, [["first", "second", "third"]]),
-            'b2': (hp.uniform, [0.05, 1.0]),
+            'b1': {
+                'hyperopt-dist': hp.choice,
+                'sampling-scope': [["first", "second", "third"]],
+                'type': 'categorical'
+            },
+            'b2': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [0.05, 1.0],
+                'type': 'continuous'
+            },
         },
         'e': {
-            'e1': (hp.uniform, [0.05, 1.0]),
-            'e2': (hp.uniform, [0.05, 1.0])
+            'e1': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [0.05, 1.0],
+                'type': 'continuous'
+            },
+            'e2': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [0.05, 1.0],
+                'type': 'continuous'
+            }
         },
         'k': {
-            'k': (hp.uniform, [1e-2, 10.0])
+            'k': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [1e-2, 10.0],
+                'type': 'continuous'
+            }
         }}
     return SearchSpace(params_per_operation)
 
 
-@pytest.mark.parametrize('tuner_cls', [SimultaneousTuner, SequentialTuner])
+@pytest.mark.parametrize('tuner_cls', [SimultaneousTuner, SequentialTuner, IOptTuner])
 @pytest.mark.parametrize('graph, adapter, obj_eval',
                          [(mock_graph_with_params(), MockAdapter(),
                            MockObjectiveEvaluate(Objective({'random_metric': CustomMetric.get_value}))),
@@ -57,7 +85,7 @@ def test_tuner_improves_metric(search_space, tuner_cls, graph, adapter, obj_eval
     assert init_metric < final_metric
 
 
-@pytest.mark.parametrize('tuner_cls', [SimultaneousTuner, SequentialTuner])
+@pytest.mark.parametrize('tuner_cls', [SimultaneousTuner, SequentialTuner, IOptTuner])
 @pytest.mark.parametrize('graph, adapter, obj_eval',
                          [(not_tunable_mock_graph(), MockAdapter(),
                            MockObjectiveEvaluate(Objective({'random_metric': CustomMetric.get_value})))])


### PR DESCRIPTION
- Adds new `IOptTuner` 
- New base class for tuners is introduced `BaseTuner` 
- The way search space is defined is changed

Concerns:
- inconvenient way to define search space. IOpt needs this division on descrete and continuous parameters, which requires additional info in search space
- IOpt does not support nested search space, which can be nessesary for some operations optimisation in FEDOT (https://github.com/aimclub/FEDOT/blob/master/fedot/core/pipelines/tuning/search_space.py#L137-L154)


IOpt supports only continuous parameters, so discrete ones are optimised as continuous and are rounded. Also there is no support for timeout and initial point.

Despite this, on classification task IOpt oftenly outperformes huperopt (but also usually takes more time, especially when search space has a lot of dimentions)

Metric improvement comparison
![tuner comp metric](https://user-images.githubusercontent.com/43475193/231725489-29d5c81c-fd81-4a71-8927-b33cfa9407b8.png)


Time spent
![tuner comp time](https://user-images.githubusercontent.com/43475193/231725662-f54faef6-3aa2-4da4-89f8-5ba06af8d149.png)
