### PR TITLE
Minor fixes in OptHistory

### DIFF
--- a/golem/core/optimisers/opt_history_objects/opt_history.py
+++ b/golem/core/optimisers/opt_history_objects/opt_history.py
@@ -249,6 +249,10 @@ class OptHistory:
             'Please, use "OptHistory.generations" to access generations.')
         return self.generations
 
+    @individuals.setter
+    def individuals(self, value):
+        self.generations = value
+
     @property
     def _log(self):
         return default_log(self)

--- a/golem/core/optimisers/opt_history_objects/opt_history.py
+++ b/golem/core/optimisers/opt_history_objects/opt_history.py
@@ -38,7 +38,6 @@ class OptHistory:
         self.individuals: List[Generation] = []
         self.archive_history: List[List[Individual]] = []
         self._tuning_result: Optional[Graph] = None
-        self._log = default_log(self)
 
         # init default save directory
         if default_save_dir:
@@ -234,3 +233,7 @@ class OptHistory:
     @tuning_result.setter
     def tuning_result(self, val):
         self._tuning_result = val
+
+    @property
+    def _log(self):
+        return default_log(self)

--- a/golem/serializers/coders/opt_history_serialization.py
+++ b/golem/serializers/coders/opt_history_serialization.py
@@ -44,8 +44,8 @@ def _archive_to_uids(generations_list: List[List[Individual]]) -> List[List[str]
 
 def opt_history_to_json(obj: OptHistory) -> Dict[str, Any]:
     serialized = any_to_json(obj)
-    serialized['individuals_pool'] = _flatten_generations_list(serialized['individuals'])
-    serialized['individuals'] = _generations_list_to_uids(serialized['individuals'])
+    serialized['individuals_pool'] = _flatten_generations_list(serialized['_generations'])
+    serialized['_generations'] = _generations_list_to_uids(serialized['_generations'])
     serialized['archive_history'] = _archive_to_uids(serialized['archive_history'])
     return serialized
 
@@ -99,19 +99,23 @@ def opt_history_from_json(cls: Type[OptHistory], json_obj: Dict[str, Any]) -> Op
         json_obj['_objective'] = ObjectiveInfo(json_obj['_is_multi_objective'])
         del json_obj['_is_multi_objective']
 
+    # OptHistory.individuals are now OptHistory._generations
+    if 'individuals' in json_obj:
+        json_obj['_generations'] = json_obj.pop('individuals')
+
     history = any_from_json(cls, json_obj)
     # Read all individuals from history.
     individuals_pool = history.individuals_pool
     uid_to_individual_map = {ind.uid: ind for ind in individuals_pool}
     # The attributes `individuals` and `archive_history` at the moment contain uid strings that must be converted
     # to `Individual` instances.
-    _deserialize_generations_list(history.individuals, uid_to_individual_map)
+    _deserialize_generations_list(history.generations, uid_to_individual_map)
     _deserialize_generations_list(history.archive_history, uid_to_individual_map)
     # Process older histories to wrap generations into the new class.
-    if isinstance(history.individuals[0], list):
-        history.individuals = [Generation(gen, gen_num) for gen_num, gen in enumerate(history.individuals)]
+    if isinstance(history.generations[0], list):
+        history.generations = [Generation(gen, gen_num) for gen_num, gen in enumerate(history.generations)]
     # Deserialize parents for all generations.
-    _deserialize_parent_individuals(list(chain(*history.individuals)), uid_to_individual_map)
+    _deserialize_parent_individuals(list(chain(*history.generations)), uid_to_individual_map)
     # The attribute is used only for serialization.
     del history.individuals_pool
     return history

--- a/golem/visualisation/opt_history/arg_constraint_wrapper.py
+++ b/golem/visualisation/opt_history/arg_constraint_wrapper.py
@@ -12,7 +12,7 @@ ArgConstraintChecker = Callable[..., Dict[str, Any]]
 
 def per_time(visualization: HistoryVisualization, **kwargs) -> Dict[str, Any]:
     value = kwargs.get('per_time')
-    if value and visualization.history.individuals[0][0].metadata.get('evaluation_time_iso') is None:
+    if value and visualization.history.generations[0][0].metadata.get('evaluation_time_iso') is None:
         visualization.log.warning('Evaluation time not found in optimization history. '
                                   'Showing fitness line per generations...')
         kwargs['per_time'] = False

--- a/golem/visualisation/opt_history/fitness_box.py
+++ b/golem/visualisation/opt_history/fitness_box.py
@@ -39,7 +39,7 @@ class FitnessBox(HistoryVisualization):
         ax.set_title('Fitness by generations')
         ax.set_xlabel('Generation')
         # Set ticks for every 5 generation if there's more than 10 generations.
-        if len(self.history.individuals) > 10:
+        if len(self.history.generations) > 10:
             ax.xaxis.set_major_locator(ticker.MultipleLocator(5))
             ax.xaxis.set_major_formatter(ticker.ScalarFormatter())
             ax.xaxis.grid(True)

--- a/golem/visualisation/opt_history/fitness_line.py
+++ b/golem/visualisation/opt_history/fitness_line.py
@@ -150,10 +150,10 @@ class FitnessLine(HistoryVisualization):
         fig, ax = plt.subplots(figsize=(6.4, 4.8), facecolor='w')
         if per_time:
             xlabel = 'Time, s'
-            plot_fitness_line_per_time(ax, self.history.individuals)
+            plot_fitness_line_per_time(ax, self.history.generations)
         else:
             xlabel = 'Generation'
-            plot_fitness_line_per_generations(ax, self.history.individuals)
+            plot_fitness_line_per_generations(ax, self.history.generations)
         setup_fitness_plot(ax, xlabel)
         show_or_save_figure(fig, save_path, dpi)
 
@@ -191,7 +191,7 @@ class FitnessLineInteractive(HistoryVisualization):
             x_template = 'generation {}'
             plot_func = plot_fitness_line_per_generations
 
-        best_individuals = plot_func(ax_fitness, self.history.individuals)
+        best_individuals = plot_func(ax_fitness, self.history.generations)
         setup_fitness_plot(ax_fitness, x_label)
 
         ax_graph.axis('off')

--- a/golem/visualisation/opt_history/fitness_line.py
+++ b/golem/visualisation/opt_history/fitness_line.py
@@ -162,7 +162,7 @@ class FitnessLineInteractive(HistoryVisualization):
 
     @with_alternate_matplotlib_backend
     def visualize(self, save_path: Optional[Union[os.PathLike, str]] = None, dpi: Optional[int] = None,
-                  per_time: Optional[bool] = None,  graph_show_kwargs: Optional[Dict[str, Any]] = None):
+                  per_time: Optional[bool] = None, graph_show_kwargs: Optional[Dict[str, Any]] = None):
         """ Visualizes the best fitness values during the evolution in the form of line.
         Additionally, shows the structure of the best individuals and the moment of their discovering.
         :param save_path: path to save the visualization. If set, then the image will be saved, and if not,

--- a/golem/visualisation/opt_history/operations_kde.py
+++ b/golem/visualisation/opt_history/operations_kde.py
@@ -70,7 +70,7 @@ class OperationsKDE(HistoryVisualization):
         fig.set_dpi(dpi)
         fig.set_facecolor('w')
         ax = plt.gca()
-        ax.set_xticks(range(len(self.history.individuals)))
+        ax.set_xticks(range(len(self.history.generations)))
         ax.locator_params(nbins=10)
         str_fraction_of_graphs = 'all' if best_fraction is None else f'top {best_fraction * 100}% of'
         ax.set_ylabel(f'Fraction in {str_fraction_of_graphs} generation graphs')

--- a/golem/visualisation/opt_history/utils.py
+++ b/golem/visualisation/opt_history/utils.py
@@ -35,7 +35,7 @@ def get_history_dataframe(history: OptHistory, best_fraction: Optional[float] = 
         tags_map = new_map
 
     uid_counts = {}  # Resolving individuals with the same uid
-    for gen_num, gen in enumerate(history.individuals):
+    for gen_num, gen in enumerate(history.generations):
         for ind in gen:
             uid_counts[ind.uid] = uid_counts.get(ind.uid, -1) + 1
             for node in ind.graph.nodes:

--- a/golem/visualisation/opt_viz_extra.py
+++ b/golem/visualisation/opt_viz_extra.py
@@ -120,7 +120,7 @@ class OptHistoryExtraVisualizer:
             self._clean(with_gif=True)
             all_historical_fitness = history.all_historical_quality(metric_index)
             historical_graphs = [ind.graph
-                                 for ind in list(itertools.chain(*history.individuals))]
+                                 for ind in list(itertools.chain(*history.generations))]
             self._visualise_graphs(historical_graphs, all_historical_fitness)
             self._visualise_convergence(all_historical_fitness)
             self._merge_images()

--- a/test/integration/test_quality_improvement.py
+++ b/test/integration/test_quality_improvement.py
@@ -45,7 +45,7 @@ def test_multiobjective_improvement(optimizer_cls, run_fun):
 
 
 def check_improvement(history: OptHistory):
-    first_pop = history.individuals[1]
+    first_pop = history.generations[1]
     pareto_front = history.archive_history[-1]
     first_pop_metrics = get_mean_metrics(first_pop)
     pareto_front_metrics = get_mean_metrics(pareto_front)

--- a/test/unit/optimizers/test_composing_history.py
+++ b/test/unit/optimizers/test_composing_history.py
@@ -64,7 +64,7 @@ def generate_history(request) -> OptHistory:
 def _test_individuals_in_history(history: OptHistory):
     uids = set()
     ids = set()
-    for ind in itertools.chain(*history.individuals):
+    for ind in itertools.chain(*history.generations):
         # All individuals in `history.individuals` must have a native generation.
         assert ind.has_native_generation
         assert ind.fitness
@@ -95,9 +95,9 @@ def test_history_adding(generate_history):
     pop_size = 10
     history = generate_history
 
-    assert len(history.individuals) == generations_quantity
+    assert len(history.generations) == generations_quantity
     for gen in range(generations_quantity):
-        assert len(history.individuals[gen]) == pop_size
+        assert len(history.generations[gen]) == pop_size
 
 
 @pytest.mark.parametrize('generate_history', [[2, 10, create_individual]], indirect=True)
@@ -107,7 +107,7 @@ def test_individual_graph_type_is_optgraph(generate_history):
     history = generate_history
     for gen in range(generations_quantity):
         for ind in range(pop_size):
-            assert type(history.individuals[gen][ind].graph) == OptGraph
+            assert type(history.generations[gen][ind].graph) == OptGraph
 
 
 def test_ancestor_for_crossover():
@@ -187,7 +187,7 @@ def test_history_save_custom_nodedata():
 
     saved = history.save()
     reloaded = OptHistory.load(saved)
-    reloaded_inds = list(itertools.chain(*reloaded.individuals))
+    reloaded_inds = list(itertools.chain(*reloaded.generations))
 
     for i, ind in enumerate(reloaded_inds):
         ind_content = ind.graph.root_node.content
@@ -218,7 +218,7 @@ def test_all_historical_quality(generate_history):
     history = generate_history
     eval_fitness = [[0.9, 0.8], [0.8, 0.6], [0.2, 0.4], [0.9, 0.9]]
     weights = (-1, 1)
-    for pop_num, population in enumerate(history.individuals):
+    for pop_num, population in enumerate(history.generations):
         if pop_num != 0:
             eval_fitness = [[fit[0] + 0.5, fit[1]] for fit in eval_fitness]
         for ind_num, individual in enumerate(population):
@@ -242,7 +242,7 @@ def test_newly_generated_history(n_jobs: int):
     history = opt.history
 
     assert history is not None
-    assert len(history.individuals) == num_of_gens + 2  # initial_assumptions + num_of_gens + final_choices
+    assert len(history.generations) == num_of_gens + 2  # initial_assumptions + num_of_gens + final_choices
     assert len(history.archive_history) == num_of_gens + 2  # initial_assumptions + num_of_gens + final_choices
     assert len(history.initial_assumptions) == 5
     assert len(history.final_choices) == 1
@@ -280,7 +280,7 @@ def test_history_correct_serialization():
     dumped_history_json = history.save()
     reloaded_history = OptHistory.load(dumped_history_json)
 
-    assert history.individuals == reloaded_history.individuals
+    assert history.generations == reloaded_history.generations
     assert dumped_history_json == reloaded_history.save(), 'The history is not equal to itself after reloading!'
     _test_individuals_in_history(reloaded_history)
 


### PR DESCRIPTION
* Turned logger into property, since logger is not serialized and thus not recreated during deseralization.
* Renamed `OptHistory.individuals` -> `generations`, added deprecation warning for the older variant.