### PR TITLE
Add new plots for population Diversity

### DIFF
--- a/examples/synthetic_graph_evolution/experiment_setup.py
+++ b/examples/synthetic_graph_evolution/experiment_setup.py
@@ -11,7 +11,7 @@ import numpy as np
 from examples.synthetic_graph_evolution.generators import generate_labeled_graph, graph_kinds
 from examples.synthetic_graph_evolution.utils import draw_graphs_subplots
 from golem.core.adapter.nx_adapter import BaseNetworkxAdapter
-from golem.core.optimisers.genetic.diversity import plot_diversity_dynamic, plot_diversity_dynamic_gif
+from golem.visualisation.opt_history.diversity import plot_diversity_dynamic, plot_diversity_dynamic_gif
 from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
 from golem.core.optimisers.optimizer import GraphOptimizer
 from golem.metrics.edit_distance import get_edit_dist_metric, matrix_edit_dist

--- a/examples/synthetic_graph_evolution/experiment_setup.py
+++ b/examples/synthetic_graph_evolution/experiment_setup.py
@@ -11,7 +11,7 @@ import numpy as np
 from examples.synthetic_graph_evolution.generators import generate_labeled_graph, graph_kinds
 from examples.synthetic_graph_evolution.utils import draw_graphs_subplots
 from golem.core.adapter.nx_adapter import BaseNetworkxAdapter
-from golem.core.optimisers.genetic.diversity import plot_diversity_dynamic
+from golem.core.optimisers.genetic.diversity import plot_diversity_dynamic, plot_diversity_dynamic_gif
 from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
 from golem.core.optimisers.optimizer import GraphOptimizer
 from golem.metrics.edit_distance import get_edit_dist_metric, matrix_edit_dist
@@ -76,6 +76,8 @@ def run_experiments(optimizer_setup: Callable,
             if visualize:
                 draw_graphs_subplots(target_graph, found_nx_graph,
                                      titles=['Target Graph', 'Found Graph'], show=False)
+                diversity_filename = (f'./results/diversity_hist_{graph_name}_n{num_nodes}.gif')
+                plot_diversity_dynamic_gif(history, filename=diversity_filename)
                 plot_diversity_dynamic(history, show=False)
                 history.show.fitness_line()
             history.save(f'./results/hist_{graph_name}_n{num_nodes}_trial{i}.json')

--- a/examples/synthetic_graph_evolution/experiment_setup.py
+++ b/examples/synthetic_graph_evolution/experiment_setup.py
@@ -11,6 +11,7 @@ import numpy as np
 from examples.synthetic_graph_evolution.generators import generate_labeled_graph, graph_kinds
 from examples.synthetic_graph_evolution.utils import draw_graphs_subplots
 from golem.core.adapter.nx_adapter import BaseNetworkxAdapter
+from golem.core.optimisers.genetic.diversity import plot_diversity_dynamic
 from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
 from golem.core.optimisers.optimizer import GraphOptimizer
 from golem.metrics.edit_distance import get_edit_dist_metric, matrix_edit_dist
@@ -74,7 +75,8 @@ def run_experiments(optimizer_setup: Callable,
             print('found graph stats: ', nxgraph_stats(found_nx_graph), file=log)
             if visualize:
                 draw_graphs_subplots(target_graph, found_nx_graph,
-                                     titles=['Target Graph', 'Found Graph'])
+                                     titles=['Target Graph', 'Found Graph'], show=False)
+                plot_diversity_dynamic(history, show=False)
                 history.show.fitness_line()
             history.save(f'./results/hist_{graph_name}_n{num_nodes}_trial{i}.json')
 

--- a/examples/synthetic_graph_evolution/experiment_setup.py
+++ b/examples/synthetic_graph_evolution/experiment_setup.py
@@ -11,7 +11,6 @@ import numpy as np
 from examples.synthetic_graph_evolution.generators import generate_labeled_graph, graph_kinds
 from examples.synthetic_graph_evolution.utils import draw_graphs_subplots
 from golem.core.adapter.nx_adapter import BaseNetworkxAdapter
-from golem.visualisation.opt_history.diversity import plot_diversity_dynamic, plot_diversity_dynamic_gif
 from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
 from golem.core.optimisers.optimizer import GraphOptimizer
 from golem.metrics.edit_distance import get_edit_dist_metric, matrix_edit_dist

--- a/examples/synthetic_graph_evolution/experiment_setup.py
+++ b/examples/synthetic_graph_evolution/experiment_setup.py
@@ -77,8 +77,8 @@ def run_experiments(optimizer_setup: Callable,
                 draw_graphs_subplots(target_graph, found_nx_graph,
                                      titles=['Target Graph', 'Found Graph'], show=False)
                 diversity_filename = (f'./results/diversity_hist_{graph_name}_n{num_nodes}.gif')
-                plot_diversity_dynamic_gif(history, filename=diversity_filename)
-                plot_diversity_dynamic(history, show=False)
+                history.show.diversity_population(save_path=diversity_filename)
+                history.show.diversity_line(show=False)
                 history.show.fitness_line()
             history.save(f'./results/hist_{graph_name}_n{num_nodes}_trial{i}.json')
 

--- a/golem/core/optimisers/genetic/diversity.py
+++ b/golem/core/optimisers/genetic/diversity.py
@@ -8,6 +8,7 @@ from numpy._typing import ArrayLike
 from golem.core.optimisers.genetic.operators.operator import PopulationT
 from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
 from golem.core.optimisers.optimizer import GraphOptimizer, IterationCallback
+from golem.visualisation.opt_history.utils import show_or_save_figure
 
 
 def compute_fitness_diversity(population: PopulationT) -> np.ndarray:
@@ -89,7 +90,8 @@ def plot_diversity_dynamic_gif(history: OptHistory,
     return animate
 
 
-def plot_diversity_dynamic(history: OptHistory, show=True):
+def plot_diversity_dynamic(history: OptHistory,
+                           show=True, save_path: Optional[str] = None, dpi: int = 100):
     labels = history.objective.metric_names
     h = history.individuals[:-1]  # don't consider final choices
     xs = np.arange(len(h))
@@ -114,5 +116,5 @@ def plot_diversity_dynamic(history: OptHistory, show=True):
     ax.grid()
     ax.legend(loc='upper left')
 
-    if show:
-        plt.show()
+    if show or save_path:
+        show_or_save_figure(fig, save_path, dpi)

--- a/golem/core/optimisers/genetic/diversity.py
+++ b/golem/core/optimisers/genetic/diversity.py
@@ -41,6 +41,7 @@ def plot_diversity_dynamic_gif(history: OptHistory,
                                fig_size: int = 5,
                                fps: int = 4,
                                ) -> FuncAnimation:
+    # TODO: make violin plot instead of histogram?
     metric_names = history.objective.metric_names
     # dtype=float removes None, puts np.nan
     # indexed by [population, metric, individual] after transpose (.T)

--- a/golem/core/optimisers/genetic/diversity.py
+++ b/golem/core/optimisers/genetic/diversity.py
@@ -1,0 +1,39 @@
+from typing import Union, Callable
+
+import numpy as np
+from matplotlib import pyplot as plt
+from numpy._typing import ArrayLike
+
+from golem.core.optimisers.genetic.operators.operator import PopulationT
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
+from golem.core.optimisers.optimizer import GraphOptimizer, IterationCallback
+
+
+def compute_fitness_diversity(population: PopulationT) -> np.ndarray:
+    """Returns numpy array of standard deviations of fitness values."""
+    # substitutes None values
+    fitness_values = np.array([ind.fitness.values for ind in population], dtype=float)
+    # compute std along each axis while ignoring nan-s
+    diversity = np.nanstd(fitness_values, axis=0)
+    return diversity
+
+
+def plot_diversity_dynamic(history: OptHistory, show=True):
+    np_history = np.array([compute_fitness_diversity(pop)
+                           for pop in history.individuals])
+    labels = history.objective.metric_names
+    xs = np.arange(len(np_history))
+    ys = {label: np_history[:, i] for i, label in enumerate(labels)}
+
+    fig, ax = plt.subplots()
+    for label, metric_std in ys.items():
+        ax.plot(xs, metric_std, label=label)
+
+    ax.set_xlabel('Generation')
+    ax.set_ylabel('Std')
+    ax.grid()
+    ax.legend()
+    fig.suptitle('Population diversity (Fitness std)')
+
+    if show:
+        plt.show()

--- a/golem/core/optimisers/genetic/diversity.py
+++ b/golem/core/optimisers/genetic/diversity.py
@@ -7,7 +7,6 @@ from numpy._typing import ArrayLike
 
 from golem.core.optimisers.genetic.operators.operator import PopulationT
 from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
-from golem.core.optimisers.optimizer import GraphOptimizer, IterationCallback
 from golem.visualisation.opt_history.utils import show_or_save_figure
 
 
@@ -18,22 +17,6 @@ def compute_fitness_diversity(population: PopulationT) -> np.ndarray:
     # compute std along each axis while ignoring nan-s
     diversity = np.nanstd(fitness_values, axis=0)
     return diversity
-
-
-class PopulationStatsLogger(IterationCallback):
-    """Stores numpy array of standard deviations of fitness values.
-    Can be used as an ``IterationCallback`` in optimizer."""
-    def __init__(self, stats_fn: Callable[[PopulationT], ArrayLike]):
-        self._stats_fn = stats_fn
-        self._history = []
-
-    def __call__(self, population: PopulationT, optimizer: GraphOptimizer) -> np.ndarray:
-        diversity = self._stats_fn(population)
-        self._history.append(diversity)
-
-    def get_history(self) -> np.ndarray:
-        np_hist = np.array(self._history)
-        return np_hist
 
 
 def plot_diversity_dynamic_gif(history: OptHistory,

--- a/golem/core/optimisers/genetic/diversity.py
+++ b/golem/core/optimisers/genetic/diversity.py
@@ -107,21 +107,29 @@ def plot_diversity_dynamic_gif(history: OptHistory,
 
 
 def plot_diversity_dynamic(history: OptHistory, show=True):
-    np_history = np.array([compute_fitness_diversity(pop)
-                           for pop in history.individuals])
     labels = history.objective.metric_names
-    xs = np.arange(len(np_history) - 2)  # don't consider first pop and final choices
-    ys = {label: np_history[1:-1, i] for i, label in enumerate(labels)}
+    h = history.individuals[:-1]  # don't consider final choices
+    xs = np.arange(len(h))
+
+    # Compute diversity by metrics
+    np_history = np.array([compute_fitness_diversity(pop) for pop in h])
+    ys = {label: np_history[:, i] for i, label in enumerate(labels)}
+    # Compute number of unique individuals, plot
+    ratio_unique = [len(set(ind.graph.descriptive_id for ind in pop)) / len(pop) for pop in h]
 
     fig, ax = plt.subplots()
     for label, metric_std in ys.items():
         ax.plot(xs, metric_std, label=label)
 
+    ax2 = ax.twinx()
+    ax2.set_ylabel('Num unique')
+    ax2.plot(xs, ratio_unique, label='Num unique', color='tab:gray')
+
+    fig.suptitle('Population diversity')
     ax.set_xlabel('Generation')
     ax.set_ylabel('Std')
     ax.grid()
-    ax.legend()
-    fig.suptitle('Population diversity (Fitness std)')
+    ax.legend(loc='upper left')
 
     if show:
         plt.show()

--- a/golem/visualisation/opt_history/diversity.py
+++ b/golem/visualisation/opt_history/diversity.py
@@ -115,7 +115,7 @@ def plot_diversity_dynamic(history: 'OptHistory',
         ax.plot(xs, metric_std, label=label, alpha=line_alpha)
 
     ax2 = ax.twinx()
-    ax2_color = 'c'  # cyan
+    ax2_color = 'm'  # magenta
     ax2.set_ylabel('Structural uniqueness', color=ax2_color)
     ax2.set_ylim(0.25, 1.05)
     ax2.tick_params(axis='y', labelcolor=ax2_color)

--- a/golem/visualisation/opt_history/diversity.py
+++ b/golem/visualisation/opt_history/diversity.py
@@ -85,18 +85,25 @@ def plot_diversity_dynamic(history: OptHistory,
     ratio_unique = [len(set(ind.graph.descriptive_id for ind in pop)) / len(pop) for pop in h]
 
     fig, ax = plt.subplots()
-    for label, metric_std in ys.items():
-        ax.plot(xs, metric_std, label=label)
-
-    ax2 = ax.twinx()
-    ax2.set_ylabel('Num unique')
-    ax2.plot(xs, ratio_unique, label='Num unique', color='tab:gray')
-
     fig.suptitle('Population diversity')
     ax.set_xlabel('Generation')
     ax.set_ylabel('Std')
     ax.grid()
-    ax.legend(loc='upper left')
+
+    for label, metric_std in ys.items():
+        ax.plot(xs, metric_std, label=label)
+
+    ax2 = ax.twinx()
+    ax2.set_ylabel('Unique ratio')
+    ax2.set_ylim(0.25, 1.0)
+    ax2.plot(xs, ratio_unique, label='unique ratio', color='tab:gray')
+
+    # ask matplotlib for the plotted objects and their labels
+    # to put them into single legend for both axes
+    lines, labels = ax.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax2.legend(lines + lines2, labels + labels2,
+               loc='upper left', bbox_to_anchor=(0., 1.15))
 
     if show or save_path:
         show_or_save_figure(fig, save_path, dpi)

--- a/golem/visualisation/opt_history/diversity.py
+++ b/golem/visualisation/opt_history/diversity.py
@@ -1,9 +1,8 @@
-from typing import Union, Callable, Sequence, Optional
+from typing import Optional
 
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.animation import FuncAnimation
-from numpy._typing import ArrayLike
 
 from golem.core.optimisers.genetic.operators.operator import PopulationT
 from golem.core.optimisers.opt_history_objects.opt_history import OptHistory

--- a/golem/visualisation/opt_history/diversity.py
+++ b/golem/visualisation/opt_history/diversity.py
@@ -15,11 +15,16 @@ if TYPE_CHECKING:
 
 class DiversityLine(HistoryVisualization):
     def visualize(self, show: bool = True, save_path: Optional[Union[os.PathLike, str]] = None):
+        """Plots double graphic to estimate diversity of populations during optimization.
+        It plots standard deviation of all metrics (y-axis) by generation number (x-axis).
+        Additional line show ratio of structurally unique individuals."""
         return plot_diversity_dynamic(self.history, show=show, save_path=save_path, dpi=self.visuals_params['dpi'])
 
 
 class DiversityPopulation(HistoryVisualization):
     def visualize(self, save_path: Union[os.PathLike, str], fps: int = 4):
+        """Creates a GIF with violin-plot estimating distribution of each metric in populations.
+        Each frame shows distribution for a particular generation."""
         return plot_diversity_dynamic_gif(self.history, filename=save_path, fps=fps, dpi=self.visuals_params['dpi'])
 
 
@@ -88,7 +93,7 @@ def plot_diversity_dynamic_gif(history: 'OptHistory',
 
 
 def plot_diversity_dynamic(history: 'OptHistory',
-                           show=True, save_path: Optional[str] = None, dpi: int = 100):
+                           show: bool = True, save_path: Optional[str] = None, dpi: int = 100):
     labels = history.objective.metric_names
     h = history.individuals[:-1]  # don't consider final choices
     xs = np.arange(len(h))
@@ -102,16 +107,20 @@ def plot_diversity_dynamic(history: 'OptHistory',
     fig, ax = plt.subplots()
     fig.suptitle('Population diversity')
     ax.set_xlabel('Generation')
-    ax.set_ylabel('Std')
+    ax.set_ylabel('Metrics Std')
     ax.grid()
+    line_alpha = 0.8
 
     for label, metric_std in ys.items():
-        ax.plot(xs, metric_std, label=label)
+        ax.plot(xs, metric_std, label=label, alpha=line_alpha)
 
     ax2 = ax.twinx()
-    ax2.set_ylabel('Unique ratio')
+    ax2_color = 'c'  # cyan
+    ax2.set_ylabel('Structural uniqueness', color=ax2_color)
     ax2.set_ylim(0.25, 1.05)
-    ax2.plot(xs, ratio_unique, label='unique ratio', color='tab:gray')
+    ax2.tick_params(axis='y', labelcolor=ax2_color)
+    ax2.plot(xs, ratio_unique, label='unique ratio',
+             color=ax2_color, linestyle='dashed', alpha=line_alpha)
 
     # ask matplotlib for the plotted objects and their labels
     # to put them into single legend for both axes

--- a/golem/visualisation/opt_history/diversity.py
+++ b/golem/visualisation/opt_history/diversity.py
@@ -1,12 +1,26 @@
-from typing import Optional
+import os
+from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.animation import FuncAnimation
 
 from golem.core.optimisers.genetic.operators.operator import PopulationT
-from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
+from golem.visualisation.opt_history.history_visualization import HistoryVisualization
 from golem.visualisation.opt_history.utils import show_or_save_figure
+
+if TYPE_CHECKING:
+    from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
+
+
+class DiversityLine(HistoryVisualization):
+    def visualize(self, show: bool = True, save_path: Optional[Union[os.PathLike, str]] = None):
+        return plot_diversity_dynamic(self.history, show=show, save_path=save_path, dpi=self.visuals_params['dpi'])
+
+
+class DiversityPopulation(HistoryVisualization):
+    def visualize(self, save_path: Union[os.PathLike, str], fps: int = 4):
+        return plot_diversity_dynamic_gif(self.history, filename=save_path, fps=fps, dpi=self.visuals_params['dpi'])
 
 
 def compute_fitness_diversity(population: PopulationT) -> np.ndarray:
@@ -18,10 +32,11 @@ def compute_fitness_diversity(population: PopulationT) -> np.ndarray:
     return diversity
 
 
-def plot_diversity_dynamic_gif(history: OptHistory,
+def plot_diversity_dynamic_gif(history: 'OptHistory',
                                filename: Optional[str] = None,
                                fig_size: int = 5,
                                fps: int = 4,
+                               dpi: int = 100,
                                ) -> FuncAnimation:
     metric_names = history.objective.metric_names
     # dtype=float removes None, puts np.nan
@@ -68,11 +83,11 @@ def plot_diversity_dynamic_gif(history: OptHistory,
     )
     # Save the GIF from animation
     if filename:
-        animate.save(filename, fps=fps, dpi=150)
+        animate.save(filename, fps=fps, dpi=dpi)
     return animate
 
 
-def plot_diversity_dynamic(history: OptHistory,
+def plot_diversity_dynamic(history: 'OptHistory',
                            show=True, save_path: Optional[str] = None, dpi: int = 100):
     labels = history.objective.metric_names
     h = history.individuals[:-1]  # don't consider final choices
@@ -95,7 +110,7 @@ def plot_diversity_dynamic(history: OptHistory,
 
     ax2 = ax.twinx()
     ax2.set_ylabel('Unique ratio')
-    ax2.set_ylim(0.25, 1.0)
+    ax2.set_ylim(0.25, 1.05)
     ax2.plot(xs, ratio_unique, label='unique ratio', color='tab:gray')
 
     # ask matplotlib for the plotted objects and their labels

--- a/golem/visualisation/opt_viz.py
+++ b/golem/visualisation/opt_viz.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from golem.core.log import default_log
+from golem.visualisation.opt_history.diversity import DiversityLine, DiversityPopulation
 from golem.visualisation.opt_history.fitness_box import FitnessBox
 from golem.visualisation.opt_history.fitness_line import FitnessLine, FitnessLineInteractive
 from golem.visualisation.opt_history.operations_animated_bar import OperationsAnimatedBar
@@ -55,6 +56,8 @@ class OptHistoryVisualizer:
         self.fitness_line_interactive = FitnessLineInteractive(history, self.visuals_params).visualize
         self.operations_kde = OperationsKDE(history, self.visuals_params).visualize
         self.operations_animated_bar = OperationsAnimatedBar(history, self.visuals_params).visualize
+        self.diversity_line = DiversityLine(history, self.visuals_params).visualize
+        self.diversity_population = DiversityPopulation(history, self.visuals_params).visualize
 
         self.log = default_log(self)
 

--- a/golem/visualisation/opt_viz.py
+++ b/golem/visualisation/opt_viz.py
@@ -89,4 +89,3 @@ class OptHistoryVisualizer:
         else:
             visualize_function = vars(self)[plot_type.name]
         visualize_function(**kwargs)
-


### PR DESCRIPTION
Add 2 new kinds of plot for estimating diversity of populations based on OptHistory.
Done as additional functionality during work on #89 

Usage example:
```
                history.show.diversity_population(save_path='diversity-dynamic.gif')  # for saving gif
                history.show.diversity_line()  # for diversity line
```

2 examples: below for multi-objective optimization with 4 metrics at once: 
- static plot howing diversity during optimization;
- GIF plot showing metric distribution per each metric in population

![Diversity plot](https://github.com/aimclub/GOLEM/assets/10994117/c2886c13-7f53-42b3-a4f9-77115175ad15)

![Diveristy GIF](https://github.com/aimclub/GOLEM/assets/10994117/b0687c04-b37e-42ea-aad0-8758f17e007d)


