### PR TITLE
Fix metric setting in tuners

### DIFF
--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -130,6 +130,7 @@ class BaseTuner(Generic[DomainGraphForTune]):
             self.log.message(f'Final metric: {abs(final_metric):.3f}')
         else:
             self.log.message('Final metric is None')
+        self.obtained_metric = final_metric
         return final_graph
 
     def get_metric_value(self, graph: OptGraph) -> float:

--- a/test/unit/tuning/test_tuning.py
+++ b/test/unit/tuning/test_tuning.py
@@ -77,12 +77,11 @@ def search_space():
                           (opt_graph_with_params(), None,
                            ObjectiveEvaluate(Objective({'random_metric': CustomMetric.get_value})))])
 def test_tuner_improves_metric(search_space, tuner_cls, graph, adapter, obj_eval):
-    init_metric = obj_eval.evaluate(graph)
     tuner = tuner_cls(obj_eval, search_space, adapter, iterations=20)
     tuned_graph = tuner.tune(deepcopy(graph))
-    final_metric = obj_eval.evaluate(tuned_graph)
-    assert final_metric is not None
-    assert init_metric < final_metric
+    assert tuned_graph is not None
+    assert tuner.obtained_metric is not None
+    assert tuner.init_metric > tuner.obtained_metric
 
 
 @pytest.mark.parametrize('tuner_cls', [SimultaneousTuner, SequentialTuner, IOptTuner])
@@ -90,22 +89,20 @@ def test_tuner_improves_metric(search_space, tuner_cls, graph, adapter, obj_eval
                          [(not_tunable_mock_graph(), MockAdapter(),
                            MockObjectiveEvaluate(Objective({'random_metric': CustomMetric.get_value})))])
 def test_tuner_with_no_tunable_params(search_space, tuner_cls, graph, adapter, obj_eval):
-    init_metric = obj_eval.evaluate(graph)
     tuner = tuner_cls(obj_eval, search_space, adapter, iterations=20)
     tuned_graph = tuner.tune(deepcopy(graph))
-    final_metric = obj_eval.evaluate(tuned_graph)
-    assert final_metric is not None
-    assert init_metric == final_metric
+    assert tuned_graph is not None
+    assert tuner.obtained_metric is not None
+    assert tuner.init_metric == tuner.obtained_metric
 
 
 @pytest.mark.parametrize('graph', [mock_graph_with_params(), opt_graph_with_params(), not_tunable_mock_graph()])
 def test_node_tuning(search_space, graph):
     obj_eval = MockObjectiveEvaluate(Objective({'random_metric': CustomMetric.get_value}))
     adapter = MockAdapter()
-    init_metric = obj_eval.evaluate(graph)
     for node_idx in range(graph.length):
         tuner = SequentialTuner(obj_eval, search_space, adapter, iterations=10)
         tuned_graph = tuner.tune_node(graph, node_idx)
-        final_metric = obj_eval.evaluate(tuned_graph)
-        assert final_metric is not None
-        assert init_metric <= final_metric
+        assert tuned_graph is not None
+        assert tuner.obtained_metric is not None
+        assert tuner.init_metric >= tuner.obtained_metric


### PR DESCRIPTION
Previously setting of `self.obtained_metric` was incorrect which was leading to integration test failing in FEDOT