### PR TITLE
Add notification after integration tests & fix the workflow badge

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -37,10 +37,11 @@ jobs:
           pytest --cov=golem -s test/integration
       - name: Notify telegram bot
         uses: appleboy/telegram-action@master
-        if: failure() # ${{ github.event_name == 'schedule' }}
+        if: failure() && ${{ github.event_name == 'schedule' }}
         with:
           to: ${{ secrets.TELEGRAM_CHAT_ID }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
-          args: 'Scheduled integration tests were failed.
-          \n
-          \nLink to the failed run - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          message: "${{ github.event.repository.name }}: scheduled integration tests 
+          [were failed](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          format: markdown
+          disable_web_page_preview: true

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -35,3 +35,12 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov=golem -s test/integration
+      - name: Notify telegram bot
+        uses: appleboy/telegram-action@master
+        if: failure() # ${{ github.event_name == 'schedule' }}
+        with:
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          args: 'Scheduled integration tests were failed.
+          \n
+          \nLink to the failed run - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,4 +1,4 @@
-name: telegram notify
+name: PR merge/close notification
 on:
   pull_request:
     types: [ closed ]

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -15,12 +15,15 @@ jobs:
         with:
           to: ${{ secrets.TELEGRAM_CHAT_ID }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
-          args: "The ${{github.event_name}} '${{github.event.pull_request.title}}' (#${{github.event.number}}) was merged.
-          \nLink: ${{github.event.pull_request.html_url}}
-          \nDescription: ${{github.event.pull_request.body}}
+          message: "${{ github.event.repository.name }}: 
+          the ${{ github.event_name }} '${{ github.event.pull_request.title }}' 
+          (#${{ github.event.number }}) was merged.
+          \n[Link](${{ github.event.pull_request.html_url }}).
+          \nDescription:\n${{ github.event.pull_request.body }}
           \n
           \nCheck it out to keep your local repository updated."
-
+          format: markdown
+          disable_web_page_preview: true
 
   close_job:
     if: github.event.pull_request.merged == false
@@ -32,4 +35,6 @@ jobs:
         with:
           to: ${{ secrets.TELEGRAM_CHAT_ID }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
-          args: The ${{github.event_name}} ${{github.event.pull_request.title}} (${{github.event.number}}) was closed.
+          message: "${{ github.event.repository.name }}: 
+          the ${{ github.event_name }} ${{ github.event.pull_request.title }} 
+          (${{ github.event.number }}) was closed."

--- a/README.rst
+++ b/README.rst
@@ -192,7 +192,7 @@ GOLEM можно установить с помощью ``pip``:
    :alt: Build Status
    :target: https://github.com/aimclub/GOLEM/actions/workflows/unit-build.yml
 
-.. |integration| image:: https://github.com/aimclub/GOLEM/workflows/integration-build.yml/badge.svg?branch=main
+.. |integration| image:: https://github.com/aimclub/GOLEM/actions/workflows/integration-build.yml/badge.svg?branch=main
    :alt: Integration Build Status
    :target: https://github.com/aimclub/GOLEM/actions/workflows/integration-build.yml
 

--- a/README_en.rst
+++ b/README_en.rst
@@ -191,7 +191,7 @@ There are various cases solved with GOLEM's algorithms:
    :alt: Build Status
    :target: https://github.com/aimclub/GOLEM/actions/workflows/unit-build.yml
 
-.. |integration| image:: https://github.com/aimclub/GOLEM/workflows/integration-build.yml/badge.svg?branch=main
+.. |integration| image:: https://github.com/aimclub/GOLEM/actions/workflows/integration-build.yml/badge.svg?branch=main
    :alt: Integration Build Status
    :target: https://github.com/aimclub/GOLEM/actions/workflows/integration-build.yml
 


### PR DESCRIPTION
- Added telegram notification if scheduled integration tests fail
- Renamed PR-related notification workflow
- Added small improvements to the notification messages (the repo name, links embedded in text, etc.)
- Fixed badge link in `README.rst` and `README_en.rst`