### PR TITLE
Hotfix condition on telegram notification of integration tests

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -37,7 +37,7 @@ jobs:
           pytest --cov=golem -s test/integration
       - name: Notify telegram bot
         uses: appleboy/telegram-action@master
-        if: failure() && ${{ github.event_name == 'schedule' }}
+        if: ${{ failure() && github.event_name == 'schedule' }}
         with:
           to: ${{ secrets.TELEGRAM_CHAT_ID }}
           token: ${{ secrets.TELEGRAM_TOKEN }}


### PR DESCRIPTION
One part of the complex condition wasn't tested, since the scheduled workflow runs on the main branch only.

After merge to main, the full condition always returns true.

Most likely, the condition is interpreted as a literal, not as an expression.