### PR TITLE
Fix recursions for cycled graphs 

### DIFF
--- a/examples/molecule_search/mol_adapter.py
+++ b/examples/molecule_search/mol_adapter.py
@@ -25,20 +25,19 @@ class MolAdapter(BaseOptimizationAdapter):
     def _adapt(self, adaptee: MolGraph) -> OptGraph:
         nx_graph = adaptee.get_nx_graph()
         digraph = nx_to_directed(nx_graph)
-        digraph = store_edges_params_in_nodes(digraph)
-        return self.nx_adapter.adapt(digraph)
+        opt_graph = self.nx_adapter.adapt(digraph)
+        opt_graph = store_edges_params_in_nodes(digraph, opt_graph)
+        return opt_graph
 
 
-def store_edges_params_in_nodes(graph: nx.DiGraph) -> nx.DiGraph:
+def store_edges_params_in_nodes(graph: nx.DiGraph, opt_graph: OptGraph) -> OptGraph:
     graph = deepcopy(graph)
-    all_edges_params = {}
     for node in graph.nodes():
         edges_params = {}
         for predecessor in graph.predecessors(node):
-            edges_params.update({predecessor: graph.get_edge_data(predecessor, node)})
-        all_edges_params.update({node: edges_params})
-    nx.set_node_attributes(graph, all_edges_params, "edges_params")
-    return graph
+            edges_params.update({str(predecessor): graph.get_edge_data(predecessor, node)})
+        opt_graph.get_node_by_uid(str(node)).content.update({'edges_params': edges_params})
+    return opt_graph
 
 
 def restore_edges_params_from_nodes(graph: nx.DiGraph) -> nx.DiGraph:

--- a/golem/core/adapter/nx_adapter.py
+++ b/golem/core/adapter/nx_adapter.py
@@ -43,7 +43,7 @@ class BaseNetworkxAdapter(BaseOptimizationAdapter[nx.DiGraph]):
         for node_id, node_data in adaptee.nodes.items():
             # transform node
             node = self._node_adapt(node_data)
-            node.uid = node_id
+            node.uid = str(node_id)
             mapped_nodes[node_id] = node
 
         # map parent nodes

--- a/golem/core/dag/graph.py
+++ b/golem/core/dag/graph.py
@@ -249,7 +249,7 @@ class Graph(ABC):
         if self.root_nodes:
             return self.root_node.descriptive_id
         else:
-            return sorted(self.nodes, key=lambda x: str(x.uid))[0].descriptive_id
+            return sorted(self.nodes, key=lambda x: x.uid)[0].descriptive_id
 
     def __str__(self):
         return str(self.graph_description)

--- a/golem/core/dag/graph.py
+++ b/golem/core/dag/graph.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
+from operator import attrgetter
 from os import PathLike
 from typing import Dict, List, Optional, Sequence, Union, Tuple, TypeVar
 
@@ -246,7 +247,10 @@ class Graph(ABC):
         Returns:
             str: text description of the content in the node and its parameters
         """
-        return self.root_node.descriptive_id
+        if self.root_nodes:
+            return self.root_node.descriptive_id
+        else:
+            return sorted(self.nodes, key=attrgetter('uid'))[0].descriptive_id
 
     def __str__(self):
         return str(self.graph_description)

--- a/golem/core/dag/graph.py
+++ b/golem/core/dag/graph.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from operator import attrgetter
 from os import PathLike
 from typing import Dict, List, Optional, Sequence, Union, Tuple, TypeVar
 

--- a/golem/core/dag/graph.py
+++ b/golem/core/dag/graph.py
@@ -250,7 +250,7 @@ class Graph(ABC):
         if self.root_nodes:
             return self.root_node.descriptive_id
         else:
-            return sorted(self.nodes, key=attrgetter('uid'))[0].descriptive_id
+            return sorted(self.nodes, key=lambda x: str(x.uid))[0].descriptive_id
 
     def __str__(self):
         return str(self.graph_description)

--- a/golem/core/dag/graph_utils.py
+++ b/golem/core/dag/graph_utils.py
@@ -1,9 +1,4 @@
-from copy import copy
-from typing import Sequence, List, TYPE_CHECKING, Callable, Optional
-
-from networkx import simple_cycles
-
-from golem.core.dag.convert import graph_structure_as_nx_graph
+from typing import Sequence, List, TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from golem.core.dag.graph import Graph

--- a/golem/core/dag/graph_utils.py
+++ b/golem/core/dag/graph_utils.py
@@ -21,18 +21,15 @@ def distance_to_root_level(graph: 'Graph', node: 'GraphNode') -> int:
         int: distance to root level
     """
 
-    def recursive_child_height(parent_node: 'GraphNode', visited_nodes: Optional[Sequence['GraphNode']] = None) -> int:
-        if visited_nodes is None:
-            visited_nodes = []
-        if parent_node in visited_nodes:
-            return -1
-        visited_nodes.append(parent_node)
+    def recursive_child_height(parent_node: 'GraphNode') -> int:
         node_child = graph.node_children(parent_node)
         if node_child:
-            height = recursive_child_height(node_child[0], copy(visited_nodes))
-            return height + 1 if height >= 0 else -1
+            height = recursive_child_height(node_child[0])
+            return height + 1
         return 0
 
+    if graph_has_cycle(graph):
+        return -1
     height = recursive_child_height(node)
     return height
 
@@ -101,16 +98,14 @@ def node_depth(node: 'GraphNode', visited_nodes: Optional[Sequence['GraphNode']]
 
     Args:
         node: where to start diving from
-
+        visited_nodes: nodes that were already visited during recursive evaluation
 
     Returns:
         int: length of a path from the provided ``node`` to the farthest primary node
     """
-    if visited_nodes is None:
-        visited_nodes = []
+    visited_nodes = visited_nodes or []
     if node in visited_nodes:
         return -1
-
     elif not node.nodes_from:
         return 1
     else:

--- a/golem/core/dag/graph_utils.py
+++ b/golem/core/dag/graph_utils.py
@@ -23,7 +23,7 @@ def distance_to_root_level(graph: 'Graph', node: 'GraphNode') -> int:
 
     def child_height(parent_node: 'GraphNode') -> int:
         height = 0
-        for _ in range(graph.depth):
+        for _ in range(graph.length):
             node_children = graph.node_children(parent_node)
             if node_children:
                 height += 1
@@ -161,6 +161,26 @@ def graph_structure(graph: 'Graph') -> str:
 
 
 def graph_has_cycle(graph: 'Graph') -> bool:
-    """ Returns True if the graph contains a cycle and False otherwise."""
-    nx_graph, _ = graph_structure_as_nx_graph(graph)
-    return len(list(simple_cycles(nx_graph))) > 0
+    """ Returns True if the graph contains a cycle and False otherwise. Implements Depth-First Search."""
+
+    visited = {node.uid: False for node in graph.nodes}
+    stack = []
+    on_stack = {node.uid: False for node in graph.nodes}
+    for node in graph.nodes:
+        if visited[node.uid]:
+            continue
+        stack.append(node)
+        while len(stack) > 0:
+            cur_node = stack[-1]
+            if not visited[cur_node.uid]:
+                visited[cur_node.uid] = True
+                on_stack[cur_node.uid] = True
+            else:
+                on_stack[cur_node.uid] = False
+                stack.pop()
+            for parent in cur_node.nodes_from:
+                if not visited[parent.uid]:
+                    stack.append(parent)
+                elif on_stack[parent.uid]:
+                    return True
+    return False

--- a/golem/core/dag/graph_utils.py
+++ b/golem/core/dag/graph_utils.py
@@ -30,7 +30,7 @@ def distance_to_root_level(graph: 'Graph', node: 'GraphNode') -> int:
         node_child = graph.node_children(parent_node)
         if node_child:
             height = recursive_child_height(node_child[0], copy(visited_nodes))
-            return height + 1 if height > 0 else -1
+            return height + 1 if height >= 0 else -1
         return 0
 
     height = recursive_child_height(node)

--- a/golem/core/dag/graph_utils.py
+++ b/golem/core/dag/graph_utils.py
@@ -103,34 +103,22 @@ def node_depth(nodes: Union['GraphNode', Sequence['GraphNode']]) -> Union[int, L
     Returns:
         int or List[int]: depth(s) of the nodes in the graph
     """
-    def calculate_depth(node, visited):
-        if node.uid in visited:
-            return -1
-        if node in final_depths:
-            return final_depths[node]
-
-        visited.add(node.uid)
-        max_depth = 0
-        for parent in node.nodes_from:
-            depth = calculate_depth(parent, visited)
-            if depth == -1:
-                return -1
-            max_depth = max(max_depth, depth)
-
-        visited.remove(node.uid)
-        final_depths[node] = max_depth + 1
-        return max_depth + 1
-
     nodes = ensure_wrapped_in_sequence(nodes)
-    final_depths = {}
-    depths = []
-    for node in nodes:
-        depth = calculate_depth(node, set())
-        if depth == -1:
-            return -1 if len(nodes) == 1 else [-1] * len(nodes)
-        depths.append(depth)
+    visited_nodes = [[node] for node in nodes]
+    depth = 1
+    parents = [node.nodes_from for node in nodes]
+    while any(parents):
+        depth += 1
+        for i, ith_parents in enumerate(parents):
+            grandparents = []
+            for parent in ith_parents:
+                if parent in visited_nodes[i]:
+                    return -1
+                grandparents.extend(parent.nodes_from)
+            visited_nodes[i].extend(ith_parents)
+            parents[i] = grandparents
 
-    return depths[0] if len(depths) == 1 else depths
+    return depth
 
 
 def map_dag_nodes(transform: Callable, nodes: Sequence) -> Sequence:

--- a/golem/core/dag/linked_graph.py
+++ b/golem/core/dag/linked_graph.py
@@ -1,15 +1,14 @@
 from copy import deepcopy
-from operator import attrgetter
 from typing import Any, Dict, List, Optional, Tuple, Union, Callable, Sequence
 
-from networkx import graph_edit_distance, set_node_attributes, simple_cycles
+from networkx import graph_edit_distance, set_node_attributes
 
+from golem.core.dag.convert import graph_structure_as_nx_graph
 from golem.core.dag.graph import Graph, ReconnectType
 from golem.core.dag.graph_node import GraphNode
 from golem.core.dag.graph_utils import ordered_subnodes_hierarchy, node_depth, graph_has_cycle
-from golem.core.dag.convert import graph_structure_as_nx_graph
-from golem.core.utilities.data_structures import ensure_wrapped_in_sequence, Copyable, remove_items
 from golem.core.paths import copy_doc
+from golem.core.utilities.data_structures import ensure_wrapped_in_sequence, Copyable, remove_items
 
 NodePostprocessCallable = Callable[[Graph, Sequence[GraphNode]], Any]
 
@@ -102,7 +101,7 @@ class LinkedGraph(Graph, Copyable):
 
     def sort_nodes(self):
         """ Layer by layer sorting """
-        if not isinstance(self.root_node, Sequence):
+        if not isinstance(self.root_node, Sequence) and not graph_has_cycle(self):
             self._nodes = ordered_subnodes_hierarchy(self.root_node)
 
     @copy_doc(Graph.node_children)
@@ -166,7 +165,7 @@ class LinkedGraph(Graph, Copyable):
         if self.root_nodes():
             return ''.join([r.descriptive_id for r in self.root_nodes()])
         else:
-            return sorted(self.nodes, key=attrgetter('uid'))[0].descriptive_id
+            return sorted(self.nodes, key=lambda x: str(x.uid))[0].descriptive_id
 
     @copy_doc(Graph.depth)
     @property

--- a/golem/core/dag/linked_graph.py
+++ b/golem/core/dag/linked_graph.py
@@ -167,7 +167,7 @@ class LinkedGraph(Graph, Copyable):
         elif self.root_nodes():
             return ''.join([r.descriptive_id for r in self.root_nodes()])
         else:
-            return sorted(self.nodes, key=lambda x: str(x.uid))[0].descriptive_id
+            return sorted(self.nodes, key=lambda x: x.uid)[0].descriptive_id
 
     @copy_doc(Graph.depth)
     @property

--- a/golem/core/dag/linked_graph.py
+++ b/golem/core/dag/linked_graph.py
@@ -162,7 +162,9 @@ class LinkedGraph(Graph, Copyable):
     @copy_doc(Graph.descriptive_id)
     @property
     def descriptive_id(self) -> str:
-        if self.root_nodes():
+        if self.length == 0:
+            return 'EMPTY'
+        elif self.root_nodes():
             return ''.join([r.descriptive_id for r in self.root_nodes()])
         else:
             return sorted(self.nodes, key=lambda x: str(x.uid))[0].descriptive_id

--- a/golem/core/dag/linked_graph.py
+++ b/golem/core/dag/linked_graph.py
@@ -177,7 +177,8 @@ class LinkedGraph(Graph, Copyable):
         elif not self.root_nodes() or graph_has_cycle(self):
             return -1
         else:
-            return max(map(node_depth, self.root_nodes()))
+            depths = node_depth(self.root_nodes())
+            return max(ensure_wrapped_in_sequence(depths))
 
     @copy_doc(Graph.get_edges)
     def get_edges(self) -> Sequence[Tuple[GraphNode, GraphNode]]:

--- a/golem/core/dag/verification_rules.py
+++ b/golem/core/dag/verification_rules.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from networkx import isolates, simple_cycles
+from networkx import isolates
 
 from golem.core.adapter import register_native
 from golem.core.dag.convert import graph_structure_as_nx_graph

--- a/golem/core/dag/verification_rules.py
+++ b/golem/core/dag/verification_rules.py
@@ -5,6 +5,7 @@ from golem.core.adapter import register_native
 from golem.core.dag.convert import graph_structure_as_nx_graph
 from golem.core.dag.graph import Graph
 from golem.core.dag.graph_node import GraphNode
+from golem.core.dag.graph_utils import graph_has_cycle
 
 ERROR_PREFIX = 'Invalid graph configuration:'
 
@@ -23,9 +24,7 @@ def has_one_root(graph: Graph):
 
 @register_native
 def has_no_cycle(graph: Graph):
-    nx_graph, _ = graph_structure_as_nx_graph(graph)
-    cycled = list(simple_cycles(nx_graph))
-    if len(cycled) > 0:
+    if graph_has_cycle(graph):
         raise ValueError(f'{ERROR_PREFIX} Graph has cycles')
 
     return True

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -110,8 +110,16 @@ def single_edge_mutation(graph: OptGraph,
     """
 
     def nodes_not_cycling(source_node: OptNode, target_node: OptNode):
-        return (target_node.descriptive_id not in
-                [n.descriptive_id for n in ordered_subnodes_hierarchy(source_node)])
+        parents = source_node.nodes_from
+        while parents:
+            if target_node not in parents:
+                grandparents = []
+                for parent in parents:
+                    grandparents.extend(parent.nodes_from)
+                parents = grandparents
+            else:
+                return False
+        return True
 
     for _ in range(parameters.max_num_of_operator_attempts):
         if len(graph.nodes) < 2 or graph.depth > requirements.max_depth:

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -12,7 +12,7 @@ from golem.core.optimisers.graph import OptGraph, OptNode
 from golem.core.optimisers.opt_node_factory import OptNodeFactory
 from golem.core.optimisers.optimization_parameters import GraphRequirements
 from golem.core.optimisers.optimizer import GraphGenerationParams, AlgorithmParameters
-from golem.core.utilities.data_structures import ComparableEnum as Enum, ensure_wrapped_in_sequence
+from golem.core.utilities.data_structures import ComparableEnum as Enum
 
 if TYPE_CHECKING:
     from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -85,6 +85,7 @@ def simple_mutation(graph: OptGraph,
             visited_nodes.add(new_node)
             for parent in node.nodes_from:
                 replace_node_to_random_recursive(parent)
+
     root_nodes = graph.root_nodes()
     root_node = choice(root_nodes) if root_nodes else None
     node_mutation_probability = get_mutation_prob(mut_id=parameters.mutation_strength,
@@ -107,6 +108,11 @@ def single_edge_mutation(graph: OptGraph,
 
     :param graph: graph to mutate
     """
+
+    def nodes_not_cycling(source_node: OptNode, target_node: OptNode):
+        return (target_node.descriptive_id not in
+                [n.descriptive_id for n in ordered_subnodes_hierarchy(source_node)])
+
     for _ in range(parameters.max_num_of_operator_attempts):
         if len(graph.nodes) < 2 or graph.depth > requirements.max_depth:
             return graph
@@ -117,9 +123,7 @@ def single_edge_mutation(graph: OptGraph,
                 graph.connect_nodes(source_node, target_node)
                 break
             else:
-                nodes_not_cycling = (target_node.descriptive_id not in
-                                     [n.descriptive_id for n in ordered_subnodes_hierarchy(source_node)])
-                if nodes_not_cycling:
+                if nodes_not_cycling(source_node, target_node):
                     graph.connect_nodes(source_node, target_node)
                     break
     return graph
@@ -370,7 +374,6 @@ base_mutations_repo = {
     MutationTypesEnum.single_change: single_change_mutation,
 }
 
-
 simple_mutation_set = (
     MutationTypesEnum.tree_growth,
     MutationTypesEnum.single_add,
@@ -381,7 +384,6 @@ simple_mutation_set = (
     # flip edge
     # cycle edge
 )
-
 
 rich_mutation_set = (
     MutationTypesEnum.simple,

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -116,8 +116,9 @@ def single_edge_mutation(graph: OptGraph,
         source_node, target_node = sample(graph.nodes, 2)
 
         if graph_has_cycle(graph):
-            graph.connect_nodes(source_node, target_node)
-            break
+            if source_node not in target_node.nodes_from:
+                graph.connect_nodes(source_node, target_node)
+                break
         else:
             nodes_not_cycling = (target_node.descriptive_id not in
                                  [n.descriptive_id for n in ordered_subnodes_hierarchy(source_node)])

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -85,7 +85,8 @@ def simple_mutation(graph: OptGraph,
             visited_nodes.add(new_node)
             for parent in node.nodes_from:
                 replace_node_to_random_recursive(parent)
-    root_node = choice(ensure_wrapped_in_sequence(graph.root_node)) if graph.root_node else None
+    root_nodes = graph.root_nodes()
+    root_node = choice(root_nodes) if root_nodes else None
     node_mutation_probability = get_mutation_prob(mut_id=parameters.mutation_strength,
                                                   node=root_node)
 

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING, Optional
 from golem.core.adapter import register_native
 from golem.core.dag.graph import ReconnectType
 from golem.core.dag.graph_node import GraphNode
-from golem.core.dag.graph_utils import distance_to_root_level, ordered_subnodes_hierarchy, distance_to_primary_level, \
-    graph_has_cycle
+from golem.core.dag.graph_utils import distance_to_root_level, distance_to_primary_level, graph_has_cycle
 from golem.core.optimisers.advisor import RemoveType
 from golem.core.optimisers.graph import OptGraph, OptNode
 from golem.core.optimisers.opt_node_factory import OptNodeFactory

--- a/golem/core/optimisers/genetic/operators/crossover.py
+++ b/golem/core/optimisers/genetic/operators/crossover.py
@@ -10,7 +10,7 @@ from golem.core.dag.graph_utils import nodes_from_layer, node_depth
 from golem.core.optimisers.genetic.gp_operators import equivalent_subtree, replace_subtrees
 from golem.core.optimisers.genetic.operators.operator import PopulationT, Operator
 from golem.core.optimisers.optimization_parameters import GraphRequirements
-from golem.core.optimisers.graph import OptGraph
+from golem.core.optimisers.graph import OptGraph, OptNode
 from golem.core.optimisers.opt_history_objects.individual import Individual
 from golem.core.optimisers.opt_history_objects.parent_operator import ParentOperator
 from golem.core.optimisers.optimizer import GraphGenerationParams
@@ -161,13 +161,13 @@ def exchange_edges_crossover(graph_first: OptGraph, graph_second: OptGraph, max_
             if parent_new:
                 parent_new = parent_new[0]
             else:
-                parent_new = GraphNode(str(parent))
+                parent_new = OptNode(str(parent))
                 graph.add_node(parent_new)
             child_new = graph.get_nodes_by_name(str(child))
             if child_new:
                 child_new = child_new[0]
             else:
-                child_new = GraphNode(str(child))
+                child_new = OptNode(str(child))
                 graph.add_node(child_new)
             new_edges.append((parent_new, child_new))
         return new_edges
@@ -212,7 +212,7 @@ def exchange_parents_one_crossover(graph_first: OptGraph, graph_second: OptGraph
             if new_node:
                 new_node = new_node[0]
             else:
-                new_node = GraphNode(str(node))
+                new_node = OptNode(str(node))
                 graph.add_node(new_node)
             new_nodes.append(new_node)
         return new_nodes
@@ -254,7 +254,7 @@ def exchange_parents_both_crossover(graph_first: OptGraph, graph_second: OptGrap
             if new_node:
                 new_node = new_node[0]
             else:
-                new_node = GraphNode(str(node))
+                new_node = OptNode(str(node))
                 graph.add_node(new_node)
             new_nodes.append(new_node)
         return new_nodes

--- a/golem/core/optimisers/genetic/operators/crossover.py
+++ b/golem/core/optimisers/genetic/operators/crossover.py
@@ -1,18 +1,17 @@
 from copy import deepcopy
-from random import choice, random, sample
-from math import ceil
 from itertools import chain
+from math import ceil
+from random import choice, random, sample
 from typing import Callable, Union, Iterable, Tuple, TYPE_CHECKING
 
 from golem.core.adapter import register_native
-from golem.core.dag.graph_node import GraphNode
 from golem.core.dag.graph_utils import nodes_from_layer, node_depth
 from golem.core.optimisers.genetic.gp_operators import equivalent_subtree, replace_subtrees
 from golem.core.optimisers.genetic.operators.operator import PopulationT, Operator
-from golem.core.optimisers.optimization_parameters import GraphRequirements
 from golem.core.optimisers.graph import OptGraph, OptNode
 from golem.core.optimisers.opt_history_objects.individual import Individual
 from golem.core.optimisers.opt_history_objects.parent_operator import ParentOperator
+from golem.core.optimisers.optimization_parameters import GraphRequirements
 from golem.core.optimisers.optimizer import GraphGenerationParams
 from golem.core.utilities.data_structures import ComparableEnum as Enum
 

--- a/golem/metrics/edit_distance.py
+++ b/golem/metrics/edit_distance.py
@@ -5,7 +5,7 @@ from typing import Optional, Callable, Dict, Sequence
 import networkx as nx
 import numpy as np
 import zss
-from networkx import graph_edit_distance
+from networkx import graph_edit_distance, is_tree
 
 from examples.synthetic_graph_evolution.generators import generate_labeled_graph
 from golem.core.optimisers.optimization_parameters import GraphRequirements
@@ -20,6 +20,8 @@ def _label_dist(label1: str, label2: str) -> int:
 def tree_edit_dist(target_graph: nx.DiGraph, graph: nx.DiGraph) -> float:
     """Compares nodes by their `name` (if present) or `uid` attribute.
     Nodes with the same name/id are considered the same."""
+    if not is_tree(target_graph) or not is_tree(graph):
+        raise ValueError('Both target graphs must be trees')
     target_tree_root = _nx_to_zss_tree(target_graph)
     cmp_tree_root = _nx_to_zss_tree(graph)
     dist = zss.simple_distance(target_tree_root, cmp_tree_root, label_dist=_label_dist)

--- a/golem/metrics/edit_distance.py
+++ b/golem/metrics/edit_distance.py
@@ -20,7 +20,7 @@ def _label_dist(label1: str, label2: str) -> int:
 def tree_edit_dist(target_graph: nx.DiGraph, graph: nx.DiGraph) -> float:
     """Compares nodes by their `name` (if present) or `uid` attribute.
     Nodes with the same name/id are considered the same."""
-    if not is_tree(target_graph) or not is_tree(graph):
+    if not (is_tree(target_graph) and is_tree(graph)):
         raise ValueError('Both target graphs must be trees')
     target_tree_root = _nx_to_zss_tree(target_graph)
     cmp_tree_root = _nx_to_zss_tree(graph)

--- a/test/integration/test_cycled_graph_evolution.py
+++ b/test/integration/test_cycled_graph_evolution.py
@@ -63,7 +63,7 @@ def test_cycled_graphs_evolution():
 def nxgraph_with_cycle(nodes_num):
     graph = nx.DiGraph()
     graph.add_nodes_from(range(nodes_num))
-    graph.add_edges_from([(i, (i + 1) % (nodes_num-1)) for i in range(nodes_num-1)])
-    graph.add_edge(nodes_num-2, nodes_num-1)
+    graph.add_edges_from([(i, (i + 1) % (nodes_num - 1)) for i in range(nodes_num - 1)])
+    graph.add_edge(nodes_num - 2, nodes_num - 1)
     graph = relabel_nx_graph(graph, available_names=('x',))
     return graph

--- a/test/integration/test_cycled_graph_evolution.py
+++ b/test/integration/test_cycled_graph_evolution.py
@@ -1,0 +1,69 @@
+from functools import partial
+
+import networkx as nx
+
+from examples.synthetic_graph_evolution.generators import relabel_nx_graph
+from golem.core.adapter.nx_adapter import BaseNetworkxAdapter
+from golem.core.dag.verification_rules import has_no_isolated_components, has_no_self_cycled_nodes, \
+    has_no_isolated_nodes
+from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
+from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters
+from golem.core.optimisers.genetic.operators.base_mutations import MutationTypesEnum
+from golem.core.optimisers.genetic.operators.crossover import CrossoverTypesEnum
+from golem.core.optimisers.objective import Objective
+from golem.core.optimisers.optimization_parameters import GraphRequirements
+from golem.core.optimisers.optimizer import GraphGenerationParams
+from golem.metrics.graph_metrics import spectral_dist
+
+
+def test_cycled_graphs_evolution():
+    target_graph = nx.DiGraph()
+    target_graph.add_nodes_from(range(18))
+    target_graph.add_edges_from([(0, 1), (1, 2), (2, 0), (2, 3),
+                                 (3, 4), (4, 5), (5, 3), (5, 6),
+                                 (6, 7), (7, 8), (8, 6), (8, 9), (9, 10), (10, 11), (11, 12), (12, 13), (13, 14),
+                                 (14, 15), (15, 16), (16, 11), (16, 17)])
+    target_graph = relabel_nx_graph(target_graph, available_names=('x',))
+    num_iterations = 50
+    objective = Objective(partial(spectral_dist, target_graph))
+
+    requirements = GraphRequirements(
+        early_stopping_iterations=num_iterations,
+        num_of_generations=num_iterations,
+        n_jobs=-1,
+        history_dir=None
+    )
+    gp_params = GPAlgorithmParameters(
+        pop_size=30,
+        mutation_types=[
+            MutationTypesEnum.single_edge,
+            MutationTypesEnum.single_add,
+            MutationTypesEnum.single_drop,
+            MutationTypesEnum.simple,
+            MutationTypesEnum.single_change
+        ],
+        crossover_types=[CrossoverTypesEnum.none]
+    )
+    graph_gen_params = GraphGenerationParams(
+        adapter=BaseNetworkxAdapter(),
+        rules_for_constraint=[has_no_isolated_components, has_no_self_cycled_nodes, has_no_isolated_nodes],
+        available_node_types=['x'],
+    )
+
+    # Generate simple initial population with cyclic graphs
+    initial_graphs = [nxgraph_with_cycle(i) for i in range(4, 20)]
+
+    optimiser = EvoGraphOptimizer(objective, initial_graphs, requirements, graph_gen_params, gp_params)
+    found_graphs = optimiser.optimise(objective)
+    found_graph: nx.DiGraph = graph_gen_params.adapter.restore(found_graphs[0])
+    assert found_graph is not None
+    assert len(found_graph.nodes) > 0
+
+
+def nxgraph_with_cycle(nodes_num):
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(nodes_num))
+    graph.add_edges_from([(i, (i + 1) % (nodes_num-1)) for i in range(nodes_num-1)])
+    graph.add_edge(nodes_num-2, nodes_num-1)
+    graph = relabel_nx_graph(graph, available_names=('x',))
+    return graph

--- a/test/integration/test_cycled_graph_evolution.py
+++ b/test/integration/test_cycled_graph_evolution.py
@@ -16,13 +16,24 @@ from golem.core.optimisers.optimizer import GraphGenerationParams
 from golem.metrics.graph_metrics import spectral_dist
 
 
+def nxgraph_with_cycle(nodes_num):
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(nodes_num))
+    graph.add_edges_from([(i, (i + 1) % (nodes_num - 1)) for i in range(nodes_num - 1)])
+    graph.add_edge(nodes_num - 2, nodes_num - 1)
+    graph = relabel_nx_graph(graph, available_names=('x',))
+    return graph
+
+
 def test_cycled_graphs_evolution():
     target_graph = nx.DiGraph()
     target_graph.add_nodes_from(range(18))
     target_graph.add_edges_from([(0, 1), (1, 2), (2, 0), (2, 3),
                                  (3, 4), (4, 5), (5, 3), (5, 6),
-                                 (6, 7), (7, 8), (8, 6), (8, 9), (9, 10), (10, 11), (11, 12), (12, 13), (13, 14),
-                                 (14, 15), (15, 16), (16, 11), (16, 17)])
+                                 (6, 7), (7, 8), (8, 6), (8, 9),
+                                 (9, 10), (10, 11), (11, 12), (12, 13),
+                                 (13, 14), (14, 15), (15, 16), (16, 11),
+                                 (16, 17)])
     target_graph = relabel_nx_graph(target_graph, available_names=('x',))
     num_iterations = 50
     objective = Objective(partial(spectral_dist, target_graph))
@@ -58,12 +69,3 @@ def test_cycled_graphs_evolution():
     found_graph: nx.DiGraph = graph_gen_params.adapter.restore(found_graphs[0])
     assert found_graph is not None
     assert len(found_graph.nodes) > 0
-
-
-def nxgraph_with_cycle(nodes_num):
-    graph = nx.DiGraph()
-    graph.add_nodes_from(range(nodes_num))
-    graph.add_edges_from([(i, (i + 1) % (nodes_num - 1)) for i in range(nodes_num - 1)])
-    graph.add_edge(nodes_num - 2, nodes_num - 1)
-    graph = relabel_nx_graph(graph, available_names=('x',))
-    return graph

--- a/test/unit/dag/test_graph_operator.py
+++ b/test/unit/dag/test_graph_operator.py
@@ -49,7 +49,8 @@ def test_sort_nodes(graph):
     new_subroot = LinkedGraphNode('new_n2', nodes_from=[new_node])
 
     # when
-    selected_node.nodes_from.append(new_subroot)
+    graph.add_node(new_subroot)
+    graph.connect_nodes(new_subroot, selected_node)
     graph.operator.sort_nodes()
 
     # then

--- a/test/unit/dag/test_graph_utils.py
+++ b/test/unit/dag/test_graph_utils.py
@@ -7,6 +7,8 @@ from test.unit.utils import graph_first, simple_cycled_graph, branched_cycled_gr
 from golem.core.dag.graph_utils import distance_to_primary_level
 from golem.core.dag.linked_graph_node import LinkedGraphNode
 
+_ = graph
+
 
 def get_nodes():
     node_a_first = LinkedGraphNode('a')

--- a/test/unit/dag/test_graph_utils.py
+++ b/test/unit/dag/test_graph_utils.py
@@ -90,11 +90,11 @@ def test_graph_has_cycle():
         assert not graph_has_cycle(not_cycled_graph)
 
 
-@pytest.mark.parametrize('graph, nodes_names, correct_depths', [(simple_cycled_graph(), ['c', 'd', 'e'], [-1, -1, -1]),
-                                                                (graph_fifth(), ['b', 'c', 'd'], [1, 3, 4]),
+@pytest.mark.parametrize('graph, nodes_names, correct_depths', [(simple_cycled_graph(), ['c', 'd', 'e'], -1),
+                                                                (graph_fifth(), ['b', 'c', 'd'], 4),
                                                                 (graph_with_multi_roots_first(), ['16', '13', '14'],
-                                                                 [3, 1, 2])])
+                                                                 3)])
 def test_node_depth(graph, nodes_names, correct_depths):
     nodes = [graph.get_nodes_by_name(name)[0] for name in nodes_names]
     depths = node_depth(nodes)
-    assert all(np.array(depths) == np.array(correct_depths))
+    assert depths == correct_depths

--- a/test/unit/dag/test_graph_utils.py
+++ b/test/unit/dag/test_graph_utils.py
@@ -1,9 +1,11 @@
+import numpy as np
 import pytest
 
 from golem.core.dag.graph_utils import nodes_from_layer, distance_to_root_level, ordered_subnodes_hierarchy, \
-    graph_has_cycle
+    graph_has_cycle, node_depth
 from test.unit.dag.test_graph_operator import graph
-from test.unit.utils import graph_first, simple_cycled_graph, branched_cycled_graph, graph_second, graph_third
+from test.unit.utils import graph_first, simple_cycled_graph, branched_cycled_graph, graph_second, graph_third, \
+    graph_fifth, graph_with_multi_roots_first
 from golem.core.dag.graph_utils import distance_to_primary_level
 from golem.core.dag.linked_graph_node import LinkedGraphNode
 
@@ -86,3 +88,13 @@ def test_graph_has_cycle():
         assert graph_has_cycle(cycled_graph)
     for not_cycled_graph in [graph_first(), graph_second(), graph_third()]:
         assert not graph_has_cycle(not_cycled_graph)
+
+
+@pytest.mark.parametrize('graph, nodes_names, correct_depths', [(simple_cycled_graph(), ['c', 'd', 'e'], [-1, -1, -1]),
+                                                                (graph_fifth(), ['b', 'c', 'd'], [1, 3, 4]),
+                                                                (graph_with_multi_roots_first(), ['16', '13', '14'],
+                                                                 [3, 1, 2])])
+def test_node_depth(graph, nodes_names, correct_depths):
+    nodes = [graph.get_nodes_by_name(name)[0] for name in nodes_names]
+    depths = node_depth(nodes)
+    assert all(np.array(depths) == np.array(correct_depths))

--- a/test/unit/dag/test_graph_utils.py
+++ b/test/unit/dag/test_graph_utils.py
@@ -1,8 +1,9 @@
 import pytest
 
-from golem.core.dag.graph_utils import nodes_from_layer, distance_to_root_level, ordered_subnodes_hierarchy
+from golem.core.dag.graph_utils import nodes_from_layer, distance_to_root_level, ordered_subnodes_hierarchy, \
+    graph_has_cycle
 from test.unit.dag.test_graph_operator import graph
-from test.unit.utils import graph_first
+from test.unit.utils import graph_first, simple_cycled_graph, branched_cycled_graph, graph_second, graph_third
 from golem.core.dag.graph_utils import distance_to_primary_level
 from golem.core.dag.linked_graph_node import LinkedGraphNode
 
@@ -76,3 +77,10 @@ def test_ordered_subnodes_cycle():
 
     with pytest.raises(ValueError, match='cycle'):
         ordered_subnodes_hierarchy(root)
+
+
+def test_graph_has_cycle():
+    for graph in [simple_cycled_graph(), branched_cycled_graph()]:
+        assert graph_has_cycle(graph)
+    for graph in [graph_first(), graph_second(), graph_third()]:
+        assert not graph_has_cycle(graph)

--- a/test/unit/dag/test_graph_utils.py
+++ b/test/unit/dag/test_graph_utils.py
@@ -82,7 +82,7 @@ def test_ordered_subnodes_cycle():
 
 
 def test_graph_has_cycle():
-    for graph in [simple_cycled_graph(), branched_cycled_graph()]:
-        assert graph_has_cycle(graph)
-    for graph in [graph_first(), graph_second(), graph_third()]:
-        assert not graph_has_cycle(graph)
+    for cycled_graph in [simple_cycled_graph(), branched_cycled_graph()]:
+        assert graph_has_cycle(cycled_graph)
+    for not_cycled_graph in [graph_first(), graph_second(), graph_third()]:
+        assert not graph_has_cycle(not_cycled_graph)

--- a/test/unit/dag/test_graph_utils.py
+++ b/test/unit/dag/test_graph_utils.py
@@ -1,13 +1,12 @@
-import numpy as np
 import pytest
 
+from golem.core.dag.graph_utils import distance_to_primary_level
 from golem.core.dag.graph_utils import nodes_from_layer, distance_to_root_level, ordered_subnodes_hierarchy, \
     graph_has_cycle, node_depth
+from golem.core.dag.linked_graph_node import LinkedGraphNode
 from test.unit.dag.test_graph_operator import graph
 from test.unit.utils import graph_first, simple_cycled_graph, branched_cycled_graph, graph_second, graph_third, \
     graph_fifth, graph_with_multi_roots_first
-from golem.core.dag.graph_utils import distance_to_primary_level
-from golem.core.dag.linked_graph_node import LinkedGraphNode
 
 _ = graph
 

--- a/test/unit/dag/test_graph_verification.py
+++ b/test/unit/dag/test_graph_verification.py
@@ -1,7 +1,26 @@
-import pytest
+from functools import partial
 
+import networkx as nx
+import pytest
+from matplotlib import pyplot as plt
+
+from examples.synthetic_graph_evolution.generators import postprocess_nx_graph, relabel_nx_graph
+from examples.synthetic_graph_evolution.utils import draw_graphs_subplots
+from golem.core.adapter.nx_adapter import BaseNetworkxAdapter
 from golem.core.dag.verification_rules import has_no_cycle, has_no_isolated_nodes, ERROR_PREFIX, \
-    has_no_self_cycled_nodes, has_no_isolated_components
+    has_no_self_cycled_nodes, has_no_isolated_components, DEFAULT_DAG_RULES
+from golem.core.optimisers.adaptive.operator_agent import MutationAgentTypeEnum
+from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
+from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters
+from golem.core.optimisers.genetic.operators.base_mutations import MutationTypesEnum
+from golem.core.optimisers.genetic.operators.crossover import CrossoverTypesEnum
+from golem.core.optimisers.genetic.operators.inheritance import GeneticSchemeTypesEnum
+from golem.core.optimisers.graph_builder import GraphBuilder
+from golem.core.optimisers.objective import Objective
+from golem.core.optimisers.optimization_parameters import GraphRequirements
+from golem.core.optimisers.optimizer import GraphGenerationParams
+from golem.metrics.edit_distance import tree_edit_dist
+from golem.metrics.graph_metrics import spectral_dist, size_diff, degree_distance
 from test.unit.mocks.common_mocks import MockNode, MockDomainStructure
 from test.unit.utils import graph_first
 
@@ -74,3 +93,61 @@ def test_graph_with_isolated_components_raise_exception():
         assert has_no_isolated_components(graph)
     assert str(exc.value) == f'{ERROR_PREFIX} Graph has isolated components'
 
+
+def test_cycled_graphs_evolution():
+    target_graph = nx.DiGraph()
+    target_graph.add_nodes_from(range(18))
+    target_graph.add_edges_from([(0, 1), (1, 2), (2, 0), (2, 3),
+                                 (3, 4), (4, 5), (5, 3), (5, 6),
+                                 (6, 7), (7, 8), (8, 6), (8, 9), (9, 10), (10, 11), (11, 12), (12, 13), (13, 14),
+                                 (14, 15), (15, 16), (16, 11), (16, 17)])
+    target_graph = relabel_nx_graph(target_graph, available_names=('x',))
+    num_iterations = 20
+    objective = Objective(partial(tree_edit_dist, target_graph))
+    max_graph_size = target_graph.number_of_nodes()
+
+    # Setup parameters
+    requirements = GraphRequirements(
+        num_of_generations=num_iterations,
+        n_jobs=-1,
+        history_dir=None
+    )
+    gp_params = GPAlgorithmParameters(
+        adaptive_mutation_type=MutationAgentTypeEnum.random,
+        pop_size=100,
+        genetic_scheme_type=GeneticSchemeTypesEnum.generational,
+        mutation_types=[
+            MutationTypesEnum.single_edge,
+            MutationTypesEnum.single_add,
+            MutationTypesEnum.single_drop,
+            MutationTypesEnum.simple,
+            MutationTypesEnum.single_change
+        ],
+        crossover_types=[CrossoverTypesEnum.none]
+    )
+    graph_gen_params = GraphGenerationParams(
+        adapter=BaseNetworkxAdapter(),
+        rules_for_constraint=[has_no_isolated_components, has_no_self_cycled_nodes, has_no_isolated_nodes],
+        available_node_types=['x'],
+    )
+
+    # Generate simple initial population with cyclic graphs
+    initial_graphs = [nxgraph_with_cycle(i) for i in range(4, 10)]
+    # Build the optimizer
+    optimiser = EvoGraphOptimizer(objective, initial_graphs, requirements, graph_gen_params, gp_params)
+    found_graphs = optimiser.optimise(objective)
+    # Restore the NetworkX graph back from internal Graph representation
+    found_graph = graph_gen_params.adapter.restore(found_graphs[0])
+    draw_graphs_subplots(target_graph, found_graph, titles=['Target Graph', 'Found Graph'])
+    optimiser.history.show.fitness_line()
+
+
+def nxgraph_with_cycle(nodes_num):
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(nodes_num))
+    graph.add_edges_from([(i, (i + 1) % (nodes_num-1)) for i in range(nodes_num-1)])
+    graph.add_edge(nodes_num-2, nodes_num-1)
+    graph = relabel_nx_graph(graph, available_names=('x',))
+    nx.draw_networkx(graph)
+    plt.show()
+    return graph

--- a/test/unit/dag/test_graph_verification.py
+++ b/test/unit/dag/test_graph_verification.py
@@ -1,26 +1,7 @@
-from functools import partial
-
-import networkx as nx
 import pytest
-from matplotlib import pyplot as plt
 
-from examples.synthetic_graph_evolution.generators import postprocess_nx_graph, relabel_nx_graph
-from examples.synthetic_graph_evolution.utils import draw_graphs_subplots
-from golem.core.adapter.nx_adapter import BaseNetworkxAdapter
 from golem.core.dag.verification_rules import has_no_cycle, has_no_isolated_nodes, ERROR_PREFIX, \
-    has_no_self_cycled_nodes, has_no_isolated_components, DEFAULT_DAG_RULES
-from golem.core.optimisers.adaptive.operator_agent import MutationAgentTypeEnum
-from golem.core.optimisers.genetic.gp_optimizer import EvoGraphOptimizer
-from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters
-from golem.core.optimisers.genetic.operators.base_mutations import MutationTypesEnum
-from golem.core.optimisers.genetic.operators.crossover import CrossoverTypesEnum
-from golem.core.optimisers.genetic.operators.inheritance import GeneticSchemeTypesEnum
-from golem.core.optimisers.graph_builder import GraphBuilder
-from golem.core.optimisers.objective import Objective
-from golem.core.optimisers.optimization_parameters import GraphRequirements
-from golem.core.optimisers.optimizer import GraphGenerationParams
-from golem.metrics.edit_distance import tree_edit_dist
-from golem.metrics.graph_metrics import spectral_dist, size_diff, degree_distance
+    has_no_self_cycled_nodes, has_no_isolated_components
 from test.unit.mocks.common_mocks import MockNode, MockDomainStructure
 from test.unit.utils import graph_first
 
@@ -92,62 +73,3 @@ def test_graph_with_isolated_components_raise_exception():
     with pytest.raises(Exception) as exc:
         assert has_no_isolated_components(graph)
     assert str(exc.value) == f'{ERROR_PREFIX} Graph has isolated components'
-
-
-def test_cycled_graphs_evolution():
-    target_graph = nx.DiGraph()
-    target_graph.add_nodes_from(range(18))
-    target_graph.add_edges_from([(0, 1), (1, 2), (2, 0), (2, 3),
-                                 (3, 4), (4, 5), (5, 3), (5, 6),
-                                 (6, 7), (7, 8), (8, 6), (8, 9), (9, 10), (10, 11), (11, 12), (12, 13), (13, 14),
-                                 (14, 15), (15, 16), (16, 11), (16, 17)])
-    target_graph = relabel_nx_graph(target_graph, available_names=('x',))
-    num_iterations = 20
-    objective = Objective(partial(tree_edit_dist, target_graph))
-    max_graph_size = target_graph.number_of_nodes()
-
-    # Setup parameters
-    requirements = GraphRequirements(
-        num_of_generations=num_iterations,
-        n_jobs=-1,
-        history_dir=None
-    )
-    gp_params = GPAlgorithmParameters(
-        adaptive_mutation_type=MutationAgentTypeEnum.random,
-        pop_size=100,
-        genetic_scheme_type=GeneticSchemeTypesEnum.generational,
-        mutation_types=[
-            MutationTypesEnum.single_edge,
-            MutationTypesEnum.single_add,
-            MutationTypesEnum.single_drop,
-            MutationTypesEnum.simple,
-            MutationTypesEnum.single_change
-        ],
-        crossover_types=[CrossoverTypesEnum.none]
-    )
-    graph_gen_params = GraphGenerationParams(
-        adapter=BaseNetworkxAdapter(),
-        rules_for_constraint=[has_no_isolated_components, has_no_self_cycled_nodes, has_no_isolated_nodes],
-        available_node_types=['x'],
-    )
-
-    # Generate simple initial population with cyclic graphs
-    initial_graphs = [nxgraph_with_cycle(i) for i in range(4, 10)]
-    # Build the optimizer
-    optimiser = EvoGraphOptimizer(objective, initial_graphs, requirements, graph_gen_params, gp_params)
-    found_graphs = optimiser.optimise(objective)
-    # Restore the NetworkX graph back from internal Graph representation
-    found_graph = graph_gen_params.adapter.restore(found_graphs[0])
-    draw_graphs_subplots(target_graph, found_graph, titles=['Target Graph', 'Found Graph'])
-    optimiser.history.show.fitness_line()
-
-
-def nxgraph_with_cycle(nodes_num):
-    graph = nx.DiGraph()
-    graph.add_nodes_from(range(nodes_num))
-    graph.add_edges_from([(i, (i + 1) % (nodes_num-1)) for i in range(nodes_num-1)])
-    graph.add_edge(nodes_num-2, nodes_num-1)
-    graph = relabel_nx_graph(graph, available_names=('x',))
-    nx.draw_networkx(graph)
-    plt.show()
-    return graph

--- a/test/unit/optimizers/gp_operators/test_mutation.py
+++ b/test/unit/optimizers/gp_operators/test_mutation.py
@@ -70,7 +70,7 @@ def test_drop_node(graph):
     params = get_mutation_params()
     for _ in range(5):
         new_graph = single_drop_mutation(new_graph, **params)
-    assert len(new_graph) < len(graph)
+    assert new_graph.length < graph.length
 
 
 @pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
@@ -78,7 +78,6 @@ def test_add_as_parent_node(graph):
     """
     Test correctness of adding as a parent
     """
-    graph = simple_linear_graph()
     new_graph = deepcopy(graph)
     node_to_mutate = new_graph.nodes[1]
     params = get_mutation_params()
@@ -101,7 +100,7 @@ def test_add_as_child_node(graph):
 
     add_as_child(new_graph, node_to_mutate, node_factory)
 
-    assert len(new_graph) > len(graph)
+    assert new_graph.length > graph.length
     assert new_graph.node_children(node_to_mutate) != graph.node_children(node_to_mutate)
 
 
@@ -117,7 +116,7 @@ def test_add_as_intermediate_node(graph):
 
     add_intermediate_node(new_graph, node_to_mutate, node_factory)
 
-    assert len(new_graph) > len(graph)
+    assert new_graph.length > graph.length
     assert node_to_mutate.nodes_from[0] != graph.nodes[1].nodes_from[0]
 
 

--- a/test/unit/optimizers/gp_operators/test_mutation.py
+++ b/test/unit/optimizers/gp_operators/test_mutation.py
@@ -23,7 +23,7 @@ from golem.core.optimisers.opt_history_objects.individual import Individual
 from golem.core.optimisers.optimization_parameters import GraphRequirements
 from golem.core.optimisers.optimizer import GraphGenerationParams
 from test.unit.utils import simple_linear_graph, tree_graph, graph_with_single_node, graph_first, \
-    graph_fifth, cycled_graph
+    graph_fifth, simple_cycled_graph
 
 available_node_types = ['a', 'b', 'c', 'd', 'e', 'f']
 
@@ -53,7 +53,7 @@ def test_mutation_none():
     assert new_graph == graph
 
 
-@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
+@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
 def test_simple_mutation(graph):
     """
     Test correctness of simple mutation
@@ -64,7 +64,7 @@ def test_simple_mutation(graph):
         assert graph.nodes[i] != new_graph.nodes[i]
 
 
-@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
+@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
 def test_drop_node(graph):
     new_graph = deepcopy(graph)
     params = get_mutation_params()
@@ -73,7 +73,7 @@ def test_drop_node(graph):
     assert new_graph.length < graph.length
 
 
-@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
+@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
 def test_add_as_parent_node(graph):
     """
     Test correctness of adding as a parent
@@ -88,7 +88,7 @@ def test_add_as_parent_node(graph):
     assert len(node_to_mutate.nodes_from) > len(graph.nodes[1].nodes_from)
 
 
-@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
+@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
 def test_add_as_child_node(graph):
     """
     Test correctness of adding as a child
@@ -104,7 +104,7 @@ def test_add_as_child_node(graph):
     assert new_graph.node_children(node_to_mutate) != graph.node_children(node_to_mutate)
 
 
-@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
+@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
 def test_add_as_intermediate_node(graph):
     """
     Test correctness of adding as an intermediate node
@@ -120,7 +120,7 @@ def test_add_as_intermediate_node(graph):
     assert node_to_mutate.nodes_from[0] != graph.nodes[1].nodes_from[0]
 
 
-@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
+@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
 def test_edge_mutation_for_graph(graph):
     """
     Tests edge mutation can add edge between nodes
@@ -130,7 +130,7 @@ def test_edge_mutation_for_graph(graph):
     assert len(new_graph.get_edges()) > len(graph.get_edges())
 
 
-@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), cycled_graph()])
+@pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
 def test_replace_mutation(graph):
     """
     Tests single_change mutation can change node to another

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -239,6 +239,17 @@ def tree_graph():
     return graph
 
 
+def cycled_graph():
+    node_a_primary = LinkedGraphNode('a')
+    node_b = LinkedGraphNode('b', nodes_from=[node_a_primary])
+    node_c = LinkedGraphNode('c', nodes_from=[node_b])
+    node_d = LinkedGraphNode('d', nodes_from=[node_c])
+    node_e = LinkedGraphNode('e', nodes_from=[node_d])
+    node_b.nodes_from.append(node_e)
+    graph = GraphDelegate(node_d)
+    return graph
+
+
 class RandomMetric:
     @staticmethod
     def get_value(graph, *args, delay=0, **kwargs) -> float:

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -101,7 +101,9 @@ def graph_fourth():
 
 
 def graph_fifth():
-    # a   b
+    # a
+    # |
+    # f   b
     #  \ /
     #   c
     #   |
@@ -109,9 +111,10 @@ def graph_fifth():
     #   |
     #   e
     node_a_primary = LinkedGraphNode('a')
+    node_f = LinkedGraphNode('f', nodes_from=[node_a_primary])
     node_b_primary = LinkedGraphNode('b')
 
-    node_c = LinkedGraphNode('c', nodes_from=[node_a_primary, node_b_primary])
+    node_c = LinkedGraphNode('c', nodes_from=[node_f, node_b_primary])
     node_d = LinkedGraphNode('d', nodes_from=[node_c])
 
     node_e = LinkedGraphNode('e', nodes_from=[node_d])
@@ -251,6 +254,7 @@ def simple_cycled_graph():
 
 
 def branched_cycled_graph():
+    #
     node_a_primary = LinkedGraphNode('a')
     node_b = LinkedGraphNode('b', nodes_from=[node_a_primary])
     node_c = LinkedGraphNode('c', nodes_from=[node_b])

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -239,7 +239,7 @@ def tree_graph():
     return graph
 
 
-def cycled_graph():
+def simple_cycled_graph():
     node_a_primary = LinkedGraphNode('a')
     node_b = LinkedGraphNode('b', nodes_from=[node_a_primary])
     node_c = LinkedGraphNode('c', nodes_from=[node_b])
@@ -247,6 +247,22 @@ def cycled_graph():
     node_e = LinkedGraphNode('e', nodes_from=[node_d])
     node_b.nodes_from.append(node_e)
     graph = GraphDelegate(node_d)
+    return graph
+
+
+def branched_cycled_graph():
+    node_a_primary = LinkedGraphNode('a')
+    node_b = LinkedGraphNode('b', nodes_from=[node_a_primary])
+    node_c = LinkedGraphNode('c', nodes_from=[node_b])
+    node_d = LinkedGraphNode('d', nodes_from=[node_c])
+    node_e = LinkedGraphNode('e', nodes_from=[node_d])
+    node_b.nodes_from.append(node_e)
+
+    node_f = LinkedGraphNode('f', nodes_from=[node_a_primary])
+    node_g = LinkedGraphNode('g', nodes_from=[node_f])
+    node_h = LinkedGraphNode('h', nodes_from=[node_f])
+
+    graph = GraphDelegate([node_d, node_g, node_h])
     return graph
 
 


### PR DESCRIPTION
Some problems with cycled graphs evolution was soleved:
- `descriptive_id` construction
- `distance_to_root_level` now returns -1 if graph has cycles
- `node_depth` returns -1 if graph has cycles
- `graph.depth` is equal -1 if graph is cycled

Some operators don't work for cycled graphs:
- `CrossoverTypesEnum.one_point`
- `CrossoverTypesEnum.subtree`
- `MutationTypesEnum.tree_growth`
- `MutationTypesEnum.growth`
- `MutationTypesEnum.local_growth`
- `MutationTypesEnum.reduce`

The reason - these crossovers use the logic of node depth and distance to primary level which can not be applyed to graphs with cycles. Also we need ordered subnodes hierarchy for subtree removal that can't be used for cycled graphs. Mutations are not available due to need to calculate distance to root level. 

Visualization of `OptGraph` does not work for cycled graphs cause it tries to aling nodes according to their hierarchy.