### PR TITLE
Fix parameter free scheme

### DIFF
--- a/golem/core/optimisers/genetic/gp_optimizer.py
+++ b/golem/core/optimisers/genetic/gp_optimizer.py
@@ -127,6 +127,9 @@ class EvoGraphOptimizer(PopulationalOptimizer):
         if not self.generations.is_any_improved:
             self.graph_optimizer_params.mutation_prob, self.graph_optimizer_params.crossover_prob = \
                 self._operators_prob.next(self.population)
+            self.log.info(
+                f'Next mutation proba: {self.graph_optimizer_params.mutation_prob}; '
+                f'Next crossover proba: {self.graph_optimizer_params.crossover_prob}')
         self.graph_optimizer_params.pop_size = self._pop_size.next(self.population)
         self.requirements.max_depth = self._graph_depth.next()
         self.log.info(

--- a/golem/core/optimisers/genetic/gp_params.py
+++ b/golem/core/optimisers/genetic/gp_params.py
@@ -59,7 +59,7 @@ class GPAlgorithmParameters(AlgorithmParameters):
 
     In the `steady_state` scheme at each iteration only one individual is updated.
 
-    The `parameter_free` scheme is an adaptive variation of the `generational` scheme.
+    The `parameter_free` scheme is an adaptive variation of the `steady_state` scheme.
     It specifies that the population size and the probability of mutation and crossover
     change depending on the success of convergence. If there are no improvements in fitness,
     then the size and the probabilities increase. When fitness improves, the size and the

--- a/golem/core/optimisers/genetic/parameters/mutation_prob.py
+++ b/golem/core/optimisers/genetic/parameters/mutation_prob.py
@@ -9,6 +9,7 @@ class AdaptiveMutationProb(AdaptiveParameter[float]):
     def __init__(self, default_prob: float = 0.5):
         self._current_std = 0.
         self._max_std = 0.
+        self._min_proba = 0.05
         self._default_prob = default_prob
 
     @property
@@ -23,7 +24,7 @@ class AdaptiveMutationProb(AdaptiveParameter[float]):
         elif self._max_std == 0:
             mutation_prob = self._default_prob
         else:
-            mutation_prob = 1. - (self._current_std / self._max_std)
+            mutation_prob = max(1. - (self._current_std / self._max_std), self._min_proba)
         return mutation_prob
 
     def _update_std(self, population: PopulationT):

--- a/golem/core/optimisers/genetic/parameters/population_size.py
+++ b/golem/core/optimisers/genetic/parameters/population_size.py
@@ -48,18 +48,13 @@ class AdaptivePopulationSize(PopulationSize):
         return self._initial
 
     def next(self, population: PopulationT) -> int:
-        fitness_improved = self._improvements.is_quality_improved
-        complexity_decreased = self._improvements.is_complexity_improved
-        progress_in_both_goals = fitness_improved and complexity_decreased
-        no_progress = not fitness_improved and not complexity_decreased
         pop_size = len(population)
-        too_many_fitness_eval_errors = \
-            pop_size / self._iterator.current() < 0.5
+        too_many_fitness_eval_errors = pop_size / self._iterator.current() < 0.5
 
-        if too_many_fitness_eval_errors or no_progress:
+        if too_many_fitness_eval_errors or not self._improvements.is_any_improved:
             if self._iterator.has_next():
                 pop_size = self._iterator.next()
-        elif progress_in_both_goals and pop_size > 0:
+        elif self._improvements.is_quality_improved and self._improvements.is_complexity_improved and pop_size > 0:
             if self._iterator.has_prev():
                 pop_size = self._iterator.prev()
 

--- a/test/integration/test_genetic_schemes.py
+++ b/test/integration/test_genetic_schemes.py
@@ -1,0 +1,42 @@
+from functools import partial
+
+import numpy as np
+import pytest
+
+from examples.synthetic_graph_evolution.experiment_setup import run_trial
+from examples.synthetic_graph_evolution.generators import generate_labeled_graph
+from examples.synthetic_graph_evolution.tree_search import tree_search_setup
+from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters
+from golem.core.optimisers.genetic.operators.base_mutations import MutationTypesEnum
+from golem.core.optimisers.genetic.operators.crossover import CrossoverTypesEnum
+from golem.core.optimisers.genetic.operators.inheritance import GeneticSchemeTypesEnum
+
+
+def set_up_params(genetic_scheme: GeneticSchemeTypesEnum):
+    gp_params = GPAlgorithmParameters(
+        multi_objective=False,
+        mutation_types=[
+            MutationTypesEnum.single_add,
+            MutationTypesEnum.single_drop,
+        ],
+        crossover_types=[CrossoverTypesEnum.none],
+        genetic_scheme_type=genetic_scheme
+    )
+    return gp_params
+
+
+@pytest.mark.parametrize('genetic_type', GeneticSchemeTypesEnum)
+def test_genetic_scheme_types(genetic_type):
+    target_graph = generate_labeled_graph('tree', 4, node_labels=['x'])
+    num_iterations = 30
+
+    gp_params = set_up_params(genetic_type)
+    found_graph, history = run_trial(target_graph=target_graph,
+                                     optimizer_setup=partial(tree_search_setup, algorithm_parameters=gp_params),
+                                     num_iterations=num_iterations)
+    assert found_graph is not None
+    # at least 20% more generation than early_stopping_iterations were evaluated
+    assert history.generations_count >= num_iterations // 3 * 1.2
+    # metric improved
+    assert np.mean([ind.fitness.value for ind in history.generations[0].data]) > \
+           np.mean([ind.fitness.value for ind in history.generations[-1].data])


### PR DESCRIPTION
The problem with `parameter_free` genetic scheme was with mutation probability. In some cases mutation probability was set to zero so there were no way to produce next generation because there were no crossover.

Added:
- minimal value for mutation probability
- minimal test for genetic schemes

Results of experiments for molecules on 5 trials for each scheme
 
![image](https://github.com/aimclub/GOLEM/assets/43475193/25636993-36cb-40e0-9f04-bd49cdb72d2c)
