### PR TITLE
Fix networkx adapter

### DIFF
--- a/examples/molecule_search/mol_adapter.py
+++ b/examples/molecule_search/mol_adapter.py
@@ -36,7 +36,7 @@ def store_edges_params_in_nodes(graph: nx.DiGraph, opt_graph: OptGraph) -> OptGr
         edges_params = {}
         for predecessor in graph.predecessors(node):
             edges_params.update({str(predecessor): graph.get_edge_data(predecessor, node)})
-        opt_graph.get_node_by_uid(str(node)).content.update({'edges_params': edges_params})
+        opt_graph.get_node_by_uid(str(node)).parameters.update({'edges_params': edges_params})
     return opt_graph
 
 

--- a/golem/core/adapter/adapter.py
+++ b/golem/core/adapter/adapter.py
@@ -81,7 +81,7 @@ class BaseOptimizationAdapter(Generic[DomainStructureType]):
         else:
             return item
 
-    def restore(self, item: Union[Graph, Individual, PopulationT]) \
+    def restore(self, item: Union[Graph, Individual, PopulationT, Sequence[Graph]]) \
             -> Union[DomainStructureType, Sequence[DomainStructureType]]:
         """Maps graphs from internal representation to domain graphs.
         Performs mapping only if argument has a type of internal representation.
@@ -98,6 +98,8 @@ class BaseOptimizationAdapter(Generic[DomainStructureType]):
             return self._restore(item.graph, item.metadata)
         elif isinstance(item, Sequence) and isinstance(item[0], Individual):
             return [self._restore(ind.graph, ind.metadata) for ind in item]
+        elif isinstance(item, Sequence) and isinstance(item[0], self.opt_graph_class):
+            return [self._restore(graph) for graph in item]
         else:
             return item
 

--- a/golem/core/adapter/nx_adapter.py
+++ b/golem/core/adapter/nx_adapter.py
@@ -22,15 +22,20 @@ class BaseNetworkxAdapter(BaseOptimizationAdapter[nx.DiGraph]):
     def _node_restore(self, node: GraphNode) -> Dict:
         """Transforms GraphNode to dict of NetworkX node attributes.
         Override for custom behavior."""
-        if hasattr(node, 'content'):
-            return deepcopy(node.content)
+        if hasattr(node, 'parameters'):
+            parameters = node.parameters
+            if node.name:
+                parameters['name'] = node.name
+            return deepcopy(parameters)
         else:
             return {}
 
     def _node_adapt(self, data: Dict) -> OptNode:
         """Transforms a dict of NetworkX node attributes to GraphNode.
         Override for custom behavior."""
-        return OptNode(content=deepcopy(data))
+        data = deepcopy(data)
+        name = data.pop('name', None)
+        return OptNode(content={'name': name, 'params': data})
 
     def _adapt(self, adaptee: nx.DiGraph) -> OptGraph:
         mapped_nodes = {}

--- a/golem/core/tuning/optuna_tuner.py
+++ b/golem/core/tuning/optuna_tuner.py
@@ -54,6 +54,9 @@ class OptunaTuner(BaseTuner):
             if init_parameters:
                 self.study.enqueue_trial(init_parameters)
 
+            verbosity_level = optuna.logging.INFO if show_progress else optuna.logging.WARNING
+            optuna.logging.set_verbosity(verbosity_level)
+
             self.study.optimize(predefined_objective,
                                 n_trials=self.iterations,
                                 n_jobs=self.n_jobs,

--- a/golem/core/tuning/tuner_interface.py
+++ b/golem/core/tuning/tuner_interface.py
@@ -136,6 +136,7 @@ class BaseTuner(Generic[DomainGraphForTune]):
                           f'worse than initial (+ {self.deviation}% deviation) {abs(init_metric):.3f}')
             final_graph = self.init_graph
             final_metric = self.init_metric
+            self.obtained_metric = final_metric
         self.log.message(f'Final graph: {graph_structure(final_graph)}')
         if final_metric is not None:
             self.log.message(f'Final metric: {abs(final_metric):.3f}')

--- a/test/unit/adapter/graph_data.py
+++ b/test/unit/adapter/graph_data.py
@@ -1,3 +1,5 @@
+import networkx as nx
+
 from golem.core.adapter.nx_adapter import DumbNetworkxAdapter, BaseNetworkxAdapter
 from test.unit.mocks.common_mocks import MockNode, MockDomainStructure, MockAdapter
 
@@ -47,6 +49,15 @@ def graph_with_custom_parameters(alpha_value):
     node_final.content['params'] = {'alpha': alpha_value}
     graph = MockDomainStructure([node_final])
 
+    return graph
+
+
+def networkx_graph_with_parameters(alpha_value):
+    graph = nx.DiGraph()
+    graph.add_node('a')
+    graph.add_node('b')
+    graph.add_node('c', alpha=alpha_value)
+    graph.add_edges_from([('a', 'c'), ('b', 'c')])
     return graph
 
 

--- a/test/unit/tuning/test_tuning.py
+++ b/test/unit/tuning/test_tuning.py
@@ -110,7 +110,7 @@ def test_node_tuning(search_space, graph):
 
 
 @pytest.mark.parametrize('tuner_cls', [OptunaTuner])
-@pytest.mark.parametrize('graph, adapter, obj_eval',
+@pytest.mark.parametrize('init_graph, adapter, obj_eval',
                          [(mock_graph_with_params(), MockAdapter(),
                            MockObjectiveEvaluate(Objective({'sum_metric': ParamsSumMetric.get_value,
                                                             'prod_metric': ParamsProductMetric.get_value},
@@ -119,11 +119,12 @@ def test_node_tuning(search_space, graph):
                            ObjectiveEvaluate(Objective({'sum_metric': ParamsSumMetric.get_value,
                                                         'prod_metric': ParamsProductMetric.get_value},
                                                        is_multi_objective=True)))])
-def test_multi_objective_tuning(search_space, tuner_cls, graph, adapter, obj_eval):
-    init_metric = obj_eval.evaluate(graph)
+def test_multi_objective_tuning(search_space, tuner_cls, init_graph, adapter, obj_eval):
+    init_metric = obj_eval.evaluate(init_graph)
     tuner = tuner_cls(obj_eval, search_space, adapter, iterations=20, objectives_number=2)
-    tuned_graphs = tuner.tune(deepcopy(graph), show_progress=False)
+    tuned_graphs = tuner.tune(deepcopy(init_graph), show_progress=False)
     for graph in tuned_graphs:
+        assert type(graph) == type(init_graph)
         final_metric = obj_eval.evaluate(graph)
         assert final_metric is not None
         assert not init_metric.dominates(final_metric)


### PR DESCRIPTION
`BaseNetworkxAdapter` refactored to process parameters of graph nodes correctly.

Also:
- adapter now can restore a list of OptGraphs
- OptunaTuner saves study (g.e. to use it for visualisations via optuna)