### PR TITLE
FEDOT integration test fix

### DIFF
--- a/golem/core/optimisers/genetic/operators/mutation.py
+++ b/golem/core/optimisers/genetic/operators/mutation.py
@@ -18,6 +18,7 @@ from golem.core.optimisers.opt_history_objects.individual import Individual
 from golem.core.optimisers.opt_history_objects.parent_operator import ParentOperator
 from golem.core.optimisers.optimization_parameters import GraphRequirements, OptimizationParameters
 from golem.core.optimisers.optimizer import GraphGenerationParams, AlgorithmParameters
+from golem.core.utilities.data_structures import ensure_wrapped_in_sequence
 
 if TYPE_CHECKING:
     from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters
@@ -70,10 +71,8 @@ class Mutation(Operator):
         return self._operator_agent
 
     def __call__(self, init_population: Union[Individual, PopulationT]) -> Union[Individual, PopulationT]:
-        if isinstance(init_population, Individual):
-            population = [init_population]
-        else:
-            population = init_population
+
+        population = ensure_wrapped_in_sequence(init_population)
 
         final_population, mutations_applied, application_attempts = tuple(zip(*map(self._mutation, population)))
 

--- a/golem/core/optimisers/genetic/operators/mutation.py
+++ b/golem/core/optimisers/genetic/operators/mutation.py
@@ -69,16 +69,20 @@ class Mutation(Operator):
     def agent(self) -> OperatorAgent:
         return self._operator_agent
 
-    def __call__(self, population: Union[Individual, PopulationT]) -> Union[Individual, PopulationT]:
-        if isinstance(population, Individual):
-            population = [population]
+    def __call__(self, init_population: Union[Individual, PopulationT]) -> Union[Individual, PopulationT]:
+        if isinstance(init_population, Individual):
+            population = [init_population]
+        else:
+            population = init_population
 
         final_population, mutations_applied, application_attempts = tuple(zip(*map(self._mutation, population)))
 
         # drop individuals to which mutations could not be applied
         final_population = [ind for ind, init_ind, attempt in zip(final_population, population, application_attempts)
                             if not attempt or ind.graph != init_ind.graph]
-        if len(population) == 1:
+        # to return the population of the same type as it was submitted (Individual -> Individual,
+        #                                                                PopulationT -> PopulationT)
+        if isinstance(init_population, Individual):
             return final_population[0] if final_population else final_population
 
         return final_population


### PR DESCRIPTION
[This](https://github.com/aimclub/FEDOT/issues/1110) issue can be resolved with types fixes in GOLEM.
The problem was in types of population before and after mutation: so if one `Individual` was submitted to the entrance, then the `Individual` must be returned, otherwise the `PopulationT` must be returned