### PR TITLE
Fix final choices saving in optimizers

### DIFF
--- a/golem/core/optimisers/meta/surrogate_optimizer.py
+++ b/golem/core/optimisers/meta/surrogate_optimizer.py
@@ -51,7 +51,7 @@ class SurrogateEachNgenOptimizer(EvoGraphOptimizer):
                         new_population = self._evolve_population(evaluator)
                 except EvaluationAttemptsError as ex:
                     self.log.warning(f'Composition process was stopped due to: {ex}')
-                    return [ind.graph for ind in self.best_individuals]
+                    break
                 # Adding of new population to history
                 self._update_population(new_population)
         self._update_population(self.best_individuals, 'final_choices')

--- a/golem/core/optimisers/populational_optimizer.py
+++ b/golem/core/optimisers/populational_optimizer.py
@@ -101,7 +101,7 @@ class PopulationalOptimizer(GraphOptimizer):
                     pbar.update()
                 except EvaluationAttemptsError as ex:
                     self.log.warning(f'Composition process was stopped due to: {ex}')
-                    return [ind.graph for ind in self.best_individuals]
+                    break
                 # Adding of new population to history
                 self._update_population(new_population)
         pbar.close()


### PR DESCRIPTION
The change uses cycle break instead of early return in optimizer. 

This allows to close the progress bar and to save the final choices to history.