### PR TITLE
Add tuning history to OptHistory

### DIFF
--- a/examples/molecule_search/experiment.py
+++ b/examples/molecule_search/experiment.py
@@ -109,7 +109,7 @@ def visualize_results(molecules: Iterable[MolGraph],
 
     # Plot pareto front (if multi-objective)
     if objective.is_multi_objective:
-        visualise_pareto(history.archive_history[-1],
+        visualise_pareto(history.evolution_best_archive[-1],
                          objectives_names=objective.metric_names[:2],
                          folder=str(save_path))
 
@@ -193,7 +193,7 @@ def run_experiment(optimizer_setup: Callable,
             result_dir = Path('results') / exp_name
             result_dir.mkdir(parents=True, exist_ok=True)
             history.save(result_dir / f'history_trial_{trial}.json')
-        trial_results.extend(history.final_choices)
+        trial_results.extend(history.evolution_results)
         trial_histories.append(history)
 
     # Compute mean & std for metrics of trials

--- a/examples/synthetic_graph_evolution/experiment_setup.py
+++ b/examples/synthetic_graph_evolution/experiment_setup.py
@@ -66,7 +66,7 @@ def run_experiments(optimizer_setup: Callable,
             found_graph = found_graphs[0] if isinstance(found_graphs, Sequence) else found_graphs
             history = optimizer.history
 
-            trial_results.extend(history.final_choices)
+            trial_results.extend(history.evolution_results)
             found_nx_graph = BaseNetworkxAdapter().restore(found_graph)
 
             duration = datetime.now() - start_time

--- a/experiments/experiment_analyzer.py
+++ b/experiments/experiment_analyzer.py
@@ -104,7 +104,7 @@ class ExperimentAnalyzer:
         # find best final metric for each objective
         best_fitness_per_objective = [np.inf] * metrics_num
         for i in range(metrics_num):
-            for ind in history.final_choices.data:
+            for ind in history.evolution_results.data:
                 if ind.fitness.values[i] < best_fitness_per_objective[i]:
                     best_fitness_per_objective[i] = ind.fitness.values[i]
 

--- a/experiments/experiment_launcher.py
+++ b/experiments/experiment_launcher.py
@@ -133,7 +133,7 @@ class GraphStructureExperimentLauncher(BaseExperimentLauncher):
                 found_graph = found_graphs[0] if isinstance(found_graphs, Sequence) else found_graphs
                 history = optimizer.history
 
-                trial_results.extend(history.final_choices)
+                trial_results.extend(history.evolution_results)
                 found_nx_graph = BaseNetworkxAdapter().restore(found_graph)
 
                 duration = datetime.now() - start_time

--- a/golem/core/optimisers/adaptive/experience_buffer.py
+++ b/golem/core/optimisers/adaptive/experience_buffer.py
@@ -57,7 +57,7 @@ class ExperienceBuffer:
         """Iterates through history and find continuous sequences of applied operator actions."""
         trajectories = []
         seen_uids = set()
-        for terminal_individual in history.final_choices:
+        for terminal_individual in history.evolution_results:
             trajectory = []
             next_ind = terminal_individual
             while True:

--- a/golem/core/optimisers/meta/surrogate_optimizer.py
+++ b/golem/core/optimisers/meta/surrogate_optimizer.py
@@ -54,5 +54,5 @@ class SurrogateEachNgenOptimizer(EvoGraphOptimizer):
                     break
                 # Adding of new population to history
                 self._update_population(new_population)
-        self._update_population(self.best_individuals, 'final_choices')
+        self._update_population(self.best_individuals, 'evolution_results')
         return [ind.graph for ind in self.best_individuals]

--- a/golem/core/optimisers/populational_optimizer.py
+++ b/golem/core/optimisers/populational_optimizer.py
@@ -105,7 +105,7 @@ class PopulationalOptimizer(GraphOptimizer):
                 # Adding of new population to history
                 self._update_population(new_population)
         pbar.close()
-        self._update_population(self.best_individuals, 'final_choices')
+        self._update_population(self.best_individuals, 'evolution_results')
         return [ind.graph for ind in self.best_individuals]
 
     @property
@@ -146,7 +146,7 @@ class PopulationalOptimizer(GraphOptimizer):
     def _log_to_history(self, population: PopulationT, label: Optional[str] = None,
                         metadata: Optional[Dict[str, Any]] = None):
         self.history.add_to_history(population, label, metadata)
-        self.history.add_to_archive_history(self.generations.best_individuals)
+        self.history.add_to_evolution_best_archive(self.generations.best_individuals)
         if self.requirements.history_dir:
             self.history.save_current_results(self.requirements.history_dir)
 

--- a/golem/core/optimisers/random/random_search.py
+++ b/golem/core/optimisers/random/random_search.py
@@ -53,7 +53,7 @@ class RandomSearchOptimizer(GraphOptimizer):
                 self.current_iteration_num += 1
                 self._update_best_individual(new_individual)
                 pbar.update()
-        self._update_best_individual(self.best_individual, 'final_choices')
+        self._update_best_individual(self.best_individual, 'evolution_results')
         pbar.close()
         return [self.best_individual.graph]
 
@@ -68,7 +68,7 @@ class RandomSearchOptimizer(GraphOptimizer):
                       f'Best individuals fitness {str(self.generations)}')
 
         self.history.add_to_history([new_individual], label)
-        self.history.add_to_archive_history(self.generations.best_individuals)
+        self.history.add_to_evolution_best_archive(self.generations.best_individuals)
 
     def _eval_initial_individual(self, evaluator: EvaluationOperator) -> Individual:
         init_ind = Individual(choice(self.initial_graphs)) if self.initial_graphs else self._generate_new_individual()

--- a/golem/core/tuning/hyperopt_tuner.py
+++ b/golem/core/tuning/hyperopt_tuner.py
@@ -10,6 +10,7 @@ from hyperopt.pyll import Apply
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.log import default_log
 from golem.core.optimisers.objective import ObjectiveFunction
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
 from golem.core.optimisers.timer import Timer
 from golem.core.tuning.search_space import SearchSpace, get_node_operation_parameter_label
 from golem.core.tuning.tuner_interface import BaseTuner
@@ -31,6 +32,7 @@ class HyperoptTuner(BaseTuner, ABC):
         By default, ``deviation=0.05``, which means that tuned graph will be returned
         if it's metric will be at least 0.05% better than the initial.
       algo: algorithm for hyperparameters optimization with signature similar to :obj:`hyperopt.tse.suggest`
+      history: object to store tuning history if needed.
     """
 
     def __init__(self, objective_evaluate: ObjectiveFunction,
@@ -41,7 +43,8 @@ class HyperoptTuner(BaseTuner, ABC):
                  timeout: timedelta = timedelta(minutes=5),
                  n_jobs: int = -1,
                  deviation: float = 0.05,
-                 algo: Callable = tpe.suggest):
+                 algo: Callable = tpe.suggest,
+                 history: Optional[OptHistory] = None):
         early_stopping_rounds = early_stopping_rounds or max(100, int(np.sqrt(iterations) * 10))
         super().__init__(objective_evaluate,
                          search_space,
@@ -50,7 +53,8 @@ class HyperoptTuner(BaseTuner, ABC):
                          early_stopping_rounds,
                          timeout,
                          n_jobs,
-                         deviation)
+                         deviation,
+                         history)
 
         self.early_stop_fn = no_progress_loss(iteration_stop_count=self.early_stopping_rounds)
         self.max_seconds = int(timeout.seconds) if timeout is not None else None

--- a/golem/core/tuning/iopt_tuner.py
+++ b/golem/core/tuning/iopt_tuner.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field
-from typing import List, Dict, Generic, Tuple, Any, Optional
+from typing import Any, Dict, Generic, List, Optional, Tuple
 
 import numpy as np
 from iOpt.method.listener import ConsoleFullOutputListener
 from iOpt.problem import Problem
 from iOpt.solver import Solver
 from iOpt.solver_parametrs import SolverParameters
-from iOpt.trial import Point, FunctionValue
+from iOpt.trial import FunctionValue, Point
 
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph

--- a/golem/core/tuning/optuna_tuner.py
+++ b/golem/core/tuning/optuna_tuner.py
@@ -10,6 +10,7 @@ from optuna.trial import FrozenTrial
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.objective import ObjectiveFunction
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
 from golem.core.tuning.search_space import SearchSpace, get_node_operation_parameter_label
 from golem.core.tuning.tuner_interface import BaseTuner, DomainGraphForTune
 
@@ -23,7 +24,8 @@ class OptunaTuner(BaseTuner):
                  timeout: timedelta = timedelta(minutes=5),
                  n_jobs: int = -1,
                  deviation: float = 0.05,
-                 objectives_number: int = 1):
+                 objectives_number: int = 1,
+                 history: Optional[OptHistory] = None):
         super().__init__(objective_evaluate,
                          search_space,
                          adapter,
@@ -31,7 +33,8 @@ class OptunaTuner(BaseTuner):
                          early_stopping_rounds,
                          timeout,
                          n_jobs,
-                         deviation)
+                         deviation,
+                         history)
         self.objectives_number = objectives_number
         self.study = None
 
@@ -82,7 +85,7 @@ class OptunaTuner(BaseTuner):
     def objective(self, trial: Trial, graph: OptGraph) -> Union[float, Sequence[float, ]]:
         new_parameters = self._get_parameters_from_trial(graph, trial)
         new_graph = BaseTuner.set_arg_graph(graph, new_parameters)
-        metric_value = self.get_metric_value(new_graph)
+        metric_value = self.evaluate_graph(new_graph)
         return metric_value
 
     def _get_parameters_from_trial(self, graph: OptGraph, trial: Trial) -> dict:

--- a/golem/core/tuning/sequential.py
+++ b/golem/core/tuning/sequential.py
@@ -7,6 +7,7 @@ from hyperopt import tpe, fmin, space_eval
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.optimisers.graph import OptGraph
 from golem.core.optimisers.objective import ObjectiveFunction
+from golem.core.optimisers.opt_history_objects.opt_history import OptHistory
 from golem.core.tuning.hyperopt_tuner import HyperoptTuner, get_node_parameters_for_hyperopt
 from golem.core.tuning.search_space import SearchSpace
 from golem.core.tuning.tuner_interface import DomainGraphForTune
@@ -26,7 +27,8 @@ class SequentialTuner(HyperoptTuner):
                  n_jobs: int = -1,
                  deviation: float = 0.05,
                  algo: Callable = tpe.suggest,
-                 inverse_node_order: bool = False):
+                 inverse_node_order: bool = False,
+                 history: Optional[OptHistory] = None):
         super().__init__(objective_evaluate,
                          search_space,
                          adapter,
@@ -34,7 +36,8 @@ class SequentialTuner(HyperoptTuner):
                          early_stopping_rounds, timeout,
                          n_jobs,
                          deviation,
-                         algo)
+                         algo,
+                         history)
 
         self.inverse_node_order = inverse_node_order
 
@@ -191,5 +194,5 @@ class SequentialTuner(HyperoptTuner):
         # Set hyperparameters for node
         graph = self.set_arg_node(graph=graph, node_id=node_id, node_params=node_params)
 
-        metric_value = self.get_metric_value(graph=graph)
+        metric_value = self.evaluate_graph(graph=graph)
         return metric_value

--- a/golem/core/tuning/simultaneous.py
+++ b/golem/core/tuning/simultaneous.py
@@ -178,6 +178,6 @@ class SimultaneousTuner(HyperoptTuner):
         # Set hyperparameters for every node
         graph = self.set_arg_graph(graph, parameters_dict)
 
-        metric_value = self.get_metric_value(graph=graph)
+        metric_value = self.evaluate_graph(graph=graph)
 
         return metric_value

--- a/golem/serializers/coders/opt_history_serialization.py
+++ b/golem/serializers/coders/opt_history_serialization.py
@@ -46,7 +46,7 @@ def opt_history_to_json(obj: OptHistory) -> Dict[str, Any]:
     serialized = any_to_json(obj)
     serialized['individuals_pool'] = _flatten_generations_list(serialized['_generations'])
     serialized['_generations'] = _generations_list_to_uids(serialized['_generations'])
-    serialized['archive_history'] = _archive_to_uids(serialized['archive_history'])
+    serialized['evolution_best_archive'] = _archive_to_uids(serialized['evolution_best_archive'])
     return serialized
 
 
@@ -103,14 +103,18 @@ def opt_history_from_json(cls: Type[OptHistory], json_obj: Dict[str, Any]) -> Op
     if 'individuals' in json_obj:
         json_obj['_generations'] = json_obj.pop('individuals')
 
+    # Renamed since #...
+    if 'archive_history' in json_obj:
+        json_obj['evolution_best_archive'] = json_obj.pop('archive_history')
+
     history = any_from_json(cls, json_obj)
     # Read all individuals from history.
     individuals_pool = history.individuals_pool
     uid_to_individual_map = {ind.uid: ind for ind in individuals_pool}
-    # The attributes `individuals` and `archive_history` at the moment contain uid strings that must be converted
-    # to `Individual` instances.
+    # The attributes `individuals` and `evolution_best_archive` at the moment contain uid strings that must
+    # be converted to `Individual` instances.
     _deserialize_generations_list(history.generations, uid_to_individual_map)
-    _deserialize_generations_list(history.archive_history, uid_to_individual_map)
+    _deserialize_generations_list(history.evolution_best_archive, uid_to_individual_map)
     # Process histories with zero generations.
     if len(history.generations) > 0:
         # Process older histories to wrap generations into the new class.

--- a/golem/visualisation/opt_history/graphs_interactive.py
+++ b/golem/visualisation/opt_history/graphs_interactive.py
@@ -37,7 +37,7 @@ class GraphsInteractive(HistoryVisualization):
 
         x_template = 'best individual #{}'
         best_individuals = {i: ind
-                            for i, ind in enumerate(self.history.archive_history[-1])}
+                            for i, ind in enumerate(self.history.evolution_best_archive[-1])}
 
         class InteractivePlot:
             temp_path = Path(default_data_dir(), 'current_graph.png')

--- a/golem/visualisation/opt_viz_extra.py
+++ b/golem/visualisation/opt_viz_extra.py
@@ -46,7 +46,7 @@ class OptHistoryExtraVisualizer:
                           objectives_numbers: Tuple[int, int] = (0, 1),
                           objectives_names: Tuple[str] = ('ROC-AUC', 'Complexity')):
         files = []
-        pareto_fronts = self.history.archive_history
+        pareto_fronts = self.history.evolution_best_archive
         individuals = self.history.generations
         array_for_analysis = individuals if individuals else pareto_fronts
         all_objectives = extract_objectives(array_for_analysis, objectives_numbers)

--- a/test/integration/test_quality_improvement.py
+++ b/test/integration/test_quality_improvement.py
@@ -46,7 +46,7 @@ def test_multiobjective_improvement(optimizer_cls, run_fun):
 
 def check_improvement(history: OptHistory):
     first_pop = history.generations[1]
-    pareto_front = history.archive_history[-1]
+    pareto_front = history.evolution_best_archive[-1]
     first_pop_metrics = get_mean_metrics(first_pop)
     pareto_front_metrics = get_mean_metrics(pareto_front)
 

--- a/test/unit/optimizers/test_composing_history.py
+++ b/test/unit/optimizers/test_composing_history.py
@@ -5,6 +5,7 @@ from random import random
 
 import numpy as np
 import pytest
+from hyperopt import hp
 
 from golem.core.optimisers.fitness.multi_objective_fitness import MultiObjFitness
 from golem.core.optimisers.genetic.evaluation import MultiprocessingDispatcher
@@ -21,6 +22,8 @@ from golem.core.optimisers.opt_history_objects.parent_operator import ParentOper
 from golem.core.optimisers.optimization_parameters import GraphRequirements
 from golem.core.optimisers.optimizer import GraphGenerationParams
 from golem.core.paths import project_root
+from golem.core.tuning.search_space import SearchSpace
+from golem.core.tuning.simultaneous import SimultaneousTuner
 from golem.visualisation.opt_viz import PlotTypesEnum, OptHistoryVisualizer
 from golem.visualisation.opt_viz_extra import OptHistoryExtraVisualizer
 from test.unit.mocks.common_mocks import MockAdapter, MockDomainStructure, MockNode, MockObjectiveEvaluate
@@ -61,11 +64,11 @@ def generate_history(request) -> OptHistory:
             new_pop.append(ind)
         history.add_to_history(new_pop)
         # since only n best individuals need to be added to archive history
-        history.add_to_archive_history([sorted(new_pop,  key=lambda ind: ind.fitness.values[0], reverse=False)[0]])
+        history.add_to_evolution_best_archive([sorted(new_pop, key=lambda ind: ind.fitness.values[0], reverse=False)[0]])
     return history
 
 
-def _test_individuals_in_history(history: OptHistory):
+def test_individuals_in_history(history: OptHistory):
     uids = set()
     ids = set()
     for ind in itertools.chain(*history.generations):
@@ -232,8 +235,57 @@ def test_all_historical_quality(generate_history):
     assert all_quality[0] == -0.9 and all_quality[4] == -1.4 and all_quality[5] == -1.3 and all_quality[10] == -1.2
 
 
+@pytest.fixture()
+def search_space():
+    params_per_operation = {
+        'a': {
+            'a1': {
+                'hyperopt-dist': hp.uniformint,
+                'sampling-scope': [2, 7],
+                'type': 'discrete'
+            },
+            'a2': {
+                'hyperopt-dist': hp.loguniform,
+                'sampling-scope': [1e-3, 1],
+                'type': 'continuous'
+            }
+        },
+        'b': {
+            'b1': {
+                'hyperopt-dist': hp.choice,
+                'sampling-scope': [["first", "second", "third"]],
+                'type': 'categorical'
+            },
+            'b2': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [0.05, 1.0],
+                'type': 'continuous'
+            },
+        },
+        'e': {
+            'e1': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [0.05, 1.0],
+                'type': 'continuous'
+            },
+            'e2': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [0.05, 1.0],
+                'type': 'continuous'
+            }
+        },
+        'f': {
+            'f': {
+                'hyperopt-dist': hp.uniform,
+                'sampling-scope': [1e-2, 10.0],
+                'type': 'continuous'
+            }
+        }}
+    return SearchSpace(params_per_operation)
+
+
 @pytest.mark.parametrize('n_jobs', [1, 2])
-def test_newly_generated_history(n_jobs: int):
+def test_newly_generated_history(n_jobs: int, search_space):
     num_of_gens = 5
     objective = Objective({'random_metric': RandomMetric.get_value})
     init_graphs = [graph_first(), graph_second(), graph_third(), graph_fourth(), graph_fifth()]
@@ -245,19 +297,32 @@ def test_newly_generated_history(n_jobs: int):
     opt.optimise(obj_eval)
     history = opt.history
 
+    tuning_iterations = 2
+    tuner = SimultaneousTuner(obj_eval, search_space, MockAdapter(), iterations=tuning_iterations, n_jobs=n_jobs,
+                              history=history)
+    tuner.tune(history.evolution_results[0].graph)
+
+    # initial_assumptions=1 + num_of_gens=5 + evolution_results=1 + tuning_start=1 +
+    #   tuning_iterations=2 + tuning_result=1 -> num_of_gens + tuning_iterations + 4
+    expected_gen_num = num_of_gens + tuning_iterations + 4
+
+    # initial_assumptions=1 + num_of_gens=5 + evolution_results=1 -> num_of_gens + 2
+    expected_evolution_gen_num = num_of_gens + 2
+
     assert history is not None
-    assert len(history.generations) == num_of_gens + 2  # initial_assumptions + num_of_gens + final_choices
-    assert len(history.archive_history) == num_of_gens + 2  # initial_assumptions + num_of_gens + final_choices
+    assert len(history.generations) == expected_gen_num
+    assert len(history.evolution_best_archive) == expected_evolution_gen_num
     assert len(history.initial_assumptions) == 5
-    assert len(history.final_choices) == 1
+    assert len(history.evolution_results) == 1
+    assert len(history.tuning_result) == 1
     assert hasattr(history, 'objective')
-    _test_individuals_in_history(history)
+    test_individuals_in_history(history)
     # Test history dumps
     dumped_history_json = history.save()
     loaded_history = OptHistory.load(dumped_history_json)
     assert dumped_history_json is not None
     assert dumped_history_json == loaded_history.save(), 'The history is not equal to itself after reloading!'
-    _test_individuals_in_history(loaded_history)
+    test_individuals_in_history(loaded_history)
 
 
 @pytest.mark.parametrize('generate_history', [[3, 4, create_individual],
@@ -300,7 +365,7 @@ def test_history_correct_serialization():
 
     assert history.generations == reloaded_history.generations
     assert dumped_history_json == reloaded_history.save(), 'The history is not equal to itself after reloading!'
-    _test_individuals_in_history(reloaded_history)
+    test_individuals_in_history(reloaded_history)
 
 
 def test_collect_intermediate_metric():
@@ -326,7 +391,7 @@ def test_load_zero_generations_history():
     path_to_history = os.path.join(project_root(), 'test', 'data', 'zero_gen_history.json')
     history = OptHistory.load(path_to_history)
     assert isinstance(history, OptHistory)
-    assert len(history.archive_history) == 0
+    assert len(history.evolution_best_archive) == 0
     assert history.objective is not None
 
 
@@ -340,9 +405,9 @@ def test_save_load_light_history(generate_history):
     assert file_name in os.listdir(path_to_dir)
     loaded_history = OptHistory().load(path_to_history)
     assert isinstance(loaded_history, OptHistory)
-    assert len(loaded_history.archive_history) == len(loaded_history.generations) == 100
+    assert len(loaded_history.evolution_best_archive) == len(loaded_history.generations) == 100
     for i, _ in enumerate(loaded_history.generations):
-        assert len(loaded_history.generations[i]) == len(loaded_history.archive_history[i]) == 1
+        assert len(loaded_history.generations[i]) == len(loaded_history.evolution_best_archive[i]) == 1
     os.remove(path=os.path.join(path_to_dir, file_name))
 
 

--- a/test/unit/serialization/test_external_serialize.py
+++ b/test/unit/serialization/test_external_serialize.py
@@ -31,7 +31,7 @@ def test_external_history_load(history_path):
 
     assert history is not None
     history_plausible(history)
-    assert len(history.individuals) > 0
+    assert len(history.generations) > 0
 
 
 def history_plausible(history: OptHistory):
@@ -44,7 +44,7 @@ def history_plausible(history: OptHistory):
         parent_operator = individual.parent_operator
         operations_correct = True
         if parent_operator:
-            type_correct = parent_operator.type_ in ['mutation', 'crossover', 'selection']
+            type_correct = parent_operator.type_ in ['mutation', 'crossover', 'selection', 'tuning']
             parent_inds_correct = all(isinstance(ind, Individual) for ind in parent_operator.parent_individuals)
             operations_correct = type_correct and parent_inds_correct
         assert graph_correct


### PR DESCRIPTION
Solves #226.

Adds an option to save graph to OptHistory after each objective evaluation in the process of tuning.

Changes OptHistory fields: 

- adds `tuning_result`
- renames `final_choices` -> `evolution_results`
- renames `archive_history` -> `evolution_best_archive`

Allows histories backward compatibility.