### PR TITLE
Fix mutation operator

### DIFF
--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -1,6 +1,9 @@
+from copy import deepcopy
 from functools import partial
-from random import choice, randint, random, sample
+from random import choice, randint, random, sample, shuffle
 from typing import TYPE_CHECKING, Optional
+
+import numpy as np
 
 from golem.core.adapter import register_native
 from golem.core.dag.graph import ReconnectType
@@ -69,7 +72,6 @@ def simple_mutation(graph: OptGraph,
 
     :param graph: graph to mutate
     """
-
     exchange_node = graph_gen_params.node_factory.exchange_node
     visited_nodes = set()
 
@@ -138,56 +140,67 @@ def single_edge_mutation(graph: OptGraph,
 
 @register_native
 def add_intermediate_node(graph: OptGraph,
-                          node_to_mutate: OptNode,
                           node_factory: OptNodeFactory) -> OptGraph:
-    # add between node and parent
-    new_node = node_factory.get_parent_node(node_to_mutate, is_primary=False)
-    if not new_node:
-        return graph
+    nodes_with_parents = [node for node in graph.nodes if node.nodes_from]
+    if len(nodes_with_parents) > 0:
+        shuffle(nodes_with_parents)
+        for node_to_mutate in nodes_with_parents:
+            # add between node and parent
+            new_node = node_factory.get_parent_node(node_to_mutate, is_primary=False)
+            if not new_node:
+                continue
 
-    # rewire old children to new parent
-    new_node.nodes_from = node_to_mutate.nodes_from
-    node_to_mutate.nodes_from = [new_node]
+            # rewire old children to new parent
+            new_node.nodes_from = node_to_mutate.nodes_from
+            node_to_mutate.nodes_from = [new_node]
 
-    # add new node to graph
-    graph.add_node(new_node)
+            # add new node to graph
+            graph.add_node(new_node)
+            break
     return graph
 
 
 @register_native
 def add_separate_parent_node(graph: OptGraph,
-                             node_to_mutate: OptNode,
                              node_factory: OptNodeFactory) -> OptGraph:
-    # add as separate parent
-    new_node = node_factory.get_parent_node(node_to_mutate, is_primary=True)
-    if not new_node:
-        # there is no possible operators
-        return graph
-    if node_to_mutate.nodes_from:
-        node_to_mutate.nodes_from.append(new_node)
-    else:
-        node_to_mutate.nodes_from = [new_node]
-    graph.nodes.append(new_node)
+    node_idx = np.arange(len(graph.nodes))
+    shuffle(node_idx)
+    for idx in node_idx:
+        node_to_mutate = graph.nodes[idx]
+        # add as separate parent
+        new_node = node_factory.get_parent_node(node_to_mutate, is_primary=True)
+        if not new_node:
+            # there is no possible operators
+            continue
+        if node_to_mutate.nodes_from:
+            node_to_mutate.nodes_from.append(new_node)
+        else:
+            node_to_mutate.nodes_from = [new_node]
+        graph.nodes.append(new_node)
+        break
     return graph
 
 
 @register_native
 def add_as_child(graph: OptGraph,
-                 node_to_mutate: OptNode,
                  node_factory: OptNodeFactory) -> OptGraph:
-    # add as child
-    old_node_children = graph.node_children(node_to_mutate)
-    new_node_child = choice(old_node_children) if old_node_children else None
-    new_node = node_factory.get_node(is_primary=False)
-    if not new_node:
-        return graph
-    graph.add_node(new_node)
-    graph.connect_nodes(node_parent=node_to_mutate, node_child=new_node)
-    if new_node_child:
-        graph.connect_nodes(node_parent=new_node, node_child=new_node_child)
-        graph.disconnect_nodes(node_parent=node_to_mutate, node_child=new_node_child,
-                               clean_up_leftovers=True)
-
+    node_idx = np.arange(len(graph.nodes))
+    shuffle(node_idx)
+    for idx in node_idx:
+        node_to_mutate = graph.nodes[idx]
+        # add as child
+        old_node_children = graph.node_children(node_to_mutate)
+        new_node_child = choice(old_node_children) if old_node_children else None
+        new_node = node_factory.get_node(is_primary=False)
+        if not new_node:
+            continue
+        graph.add_node(new_node)
+        graph.connect_nodes(node_parent=node_to_mutate, node_child=new_node)
+        if new_node_child:
+            graph.connect_nodes(node_parent=new_node, node_child=new_node_child)
+            graph.disconnect_nodes(node_parent=node_to_mutate, node_child=new_node_child,
+                                   clean_up_leftovers=True)
+        break
     return graph
 
 
@@ -202,20 +215,20 @@ def single_add_mutation(graph: OptGraph,
 
     :param graph: graph to mutate
     """
-
     if graph.depth >= requirements.max_depth:
         # add mutation is not possible
         return graph
 
-    node_to_mutate = choice(graph.nodes)
-
-    single_add_strategies = [add_as_child, add_separate_parent_node]
-    if node_to_mutate.nodes_from:
-        single_add_strategies.append(add_intermediate_node)
-    strategy = choice(single_add_strategies)
-
-    result = strategy(graph, node_to_mutate, graph_gen_params.node_factory)
-    return result
+    new_graph = deepcopy(graph)
+    single_add_strategies = [add_as_child, add_separate_parent_node, add_intermediate_node]
+    shuffle(single_add_strategies)
+    for strategy in single_add_strategies:
+        new_graph = strategy(new_graph, graph_gen_params.node_factory)
+        # maximum three equality check
+        if new_graph == graph:
+            continue
+        break
+    return new_graph
 
 
 @register_native
@@ -229,11 +242,15 @@ def single_change_mutation(graph: OptGraph,
 
     :param graph: graph to mutate
     """
-    node = choice(graph.nodes)
-    new_node = graph_gen_params.node_factory.exchange_node(node)
-    if not new_node:
-        return graph
-    graph.update_node(node, new_node)
+    node_idx = np.arange(len(graph.nodes))
+    shuffle(node_idx)
+    for idx in node_idx:
+        node = graph.nodes[idx]
+        new_node = graph_gen_params.node_factory.exchange_node(node)
+        if not new_node:
+            continue
+        graph.update_node(node, new_node)
+        break
     return graph
 
 
@@ -289,22 +306,27 @@ def tree_growth(graph: OptGraph,
     selected random node, if false then previous depth of selected node doesn't affect to
     new subtree depth, maximal depth of new subtree just should satisfy depth constraint in parent tree
     """
-    node_from_graph = choice(graph.nodes)
-    if local_growth:
-        max_depth = distance_to_primary_level(node_from_graph)
-        is_primary_node_selected = (not node_from_graph.nodes_from) or (node_from_graph != graph.root_node and
-                                                                        randint(0, 1))
-    else:
-        max_depth = requirements.max_depth - distance_to_root_level(graph, node_from_graph)
-        is_primary_node_selected = \
-            distance_to_root_level(graph, node_from_graph) >= requirements.max_depth and randint(0, 1)
-    if is_primary_node_selected:
-        new_subtree = graph_gen_params.node_factory.get_node(is_primary=True)
-        if not new_subtree:
-            return graph
-    else:
-        new_subtree = graph_gen_params.random_graph_factory(requirements, max_depth).root_node
-    graph.update_subtree(node_from_graph, new_subtree)
+    node_idx = np.arange(len(graph.nodes))
+    shuffle(node_idx)
+    for idx in node_idx:
+        node_from_graph = graph.nodes[idx]
+        if local_growth:
+            max_depth = distance_to_primary_level(node_from_graph)
+            is_primary_node_selected = (not node_from_graph.nodes_from) or (node_from_graph != graph.root_node and
+                                                                            randint(0, 1))
+        else:
+            max_depth = requirements.max_depth - distance_to_root_level(graph, node_from_graph)
+            is_primary_node_selected = \
+                distance_to_root_level(graph, node_from_graph) >= requirements.max_depth and randint(0, 1)
+        if is_primary_node_selected:
+            new_subtree = graph_gen_params.node_factory.get_node(is_primary=True)
+            if not new_subtree:
+                continue
+        else:
+            new_subtree = graph_gen_params.random_graph_factory(requirements, max_depth).root_node
+
+        graph.update_subtree(node_from_graph, new_subtree)
+        break
     return graph
 
 
@@ -349,16 +371,18 @@ def reduce_mutation(graph: OptGraph,
         return graph
 
     nodes = [node for node in graph.nodes if node is not graph.root_node]
-    node_to_del = choice(nodes)
-    children = graph.node_children(node_to_del)
-    is_possible_to_delete = all([len(child.nodes_from) - 1 >= requirements.min_arity for child in children])
-    if is_possible_to_delete:
-        graph.delete_subtree(node_to_del)
-    else:
-        primary_node = graph_gen_params.node_factory.get_node(is_primary=True)
-        if not primary_node:
-            return graph
-        graph.update_subtree(node_to_del, primary_node)
+    shuffle(nodes)
+    for node_to_del in nodes:
+        children = graph.node_children(node_to_del)
+        is_possible_to_delete = all([len(child.nodes_from) - 1 >= requirements.min_arity for child in children])
+        if is_possible_to_delete:
+            graph.delete_subtree(node_to_del)
+        else:
+            primary_node = graph_gen_params.node_factory.get_node(is_primary=True)
+            if not primary_node:
+                continue
+            graph.update_subtree(node_to_del, primary_node)
+        break
     return graph
 
 

--- a/golem/core/optimisers/genetic/operators/mutation.py
+++ b/golem/core/optimisers/genetic/operators/mutation.py
@@ -103,8 +103,12 @@ class Mutation(Operator):
                 new_graph = self._apply_mutations(new_graph, mutation_type)
                 is_correct_graph = self.graph_generation_params.verifier(new_graph)
                 if is_correct_graph:
+                    if isinstance(mutation_type, MutationTypesEnum):
+                        mutation_name = mutation_type.name
+                    else:
+                        mutation_name = mutation_type.__name__
                     parent_operator = ParentOperator(type_='mutation',
-                                                     operators=mutation_type,
+                                                     operators=mutation_name,
                                                      parent_individuals=individual)
                     individual = Individual(new_graph, parent_operator,
                                             metadata=self.requirements.static_individual_metadata)

--- a/golem/core/optimisers/genetic/operators/mutation.py
+++ b/golem/core/optimisers/genetic/operators/mutation.py
@@ -81,43 +81,42 @@ class Mutation(Operator):
         if isinstance(population, Individual):
             population = [population]
 
-        final_population, mutations_applied, application_attempts = tuple(zip(*map(self._mutation, population)))
+        final_population, application_attempts = tuple(zip(*map(self._mutation, population)))
 
         # drop individuals to which mutations could not be applied
         final_population = [ind for ind, init_ind, attempt in zip(final_population, population, application_attempts)
-                            if not attempt or ind.graph != init_ind.graph]
+                            if not(attempt and ind.graph == init_ind.graph)]
 
         if len(population) == 1:
             return final_population[0] if final_population else final_population
 
         return final_population
 
-    def _mutation(self, individual: Individual) -> Tuple[Individual, Optional[MutationIdType], bool]:
+    def _mutation(self, individual: Individual) -> Tuple[Individual, bool]:
         """ Function applies mutation operator to graph """
-        application_attempt = False
-        mutation_applied = None
-        for _ in range(self.parameters.max_num_of_operator_attempts):
-            new_graph = deepcopy(individual.graph)
+        graph = deepcopy(individual.graph)
+        mutation_type = self._operator_agent.choose_action(graph)
+        is_applied = self._will_mutation_be_applied(mutation_type)
+        if is_applied:
+            for _ in range(self.parameters.max_num_of_operator_attempts):
+                new_graph = deepcopy(individual.graph)
 
-            new_graph, mutation_applied = self._apply_mutations(new_graph)
-            if mutation_applied is None:
-                continue
-            application_attempt = True
-            is_correct_graph = self.graph_generation_params.verifier(new_graph)
-            if is_correct_graph:
-                parent_operator = ParentOperator(type_='mutation',
-                                                 operators=mutation_applied,
-                                                 parent_individuals=individual)
-                individual = Individual(new_graph, parent_operator,
-                                        metadata=self.requirements.static_individual_metadata)
-                break
+                new_graph = self._apply_mutations(new_graph, mutation_type)
+                is_correct_graph = self.graph_generation_params.verifier(new_graph)
+                if is_correct_graph and graph != new_graph:
+                    parent_operator = ParentOperator(type_='mutation',
+                                                     operators=mutation_type,
+                                                     parent_individuals=individual)
+                    individual = Individual(new_graph, parent_operator,
+                                            metadata=self.requirements.static_individual_metadata)
+                    break
             else:
                 # Collect invalid actions
-                self.agent_experience.collect_experience(individual, mutation_applied, reward=-1.0)
-        else:
-            self.log.debug('Number of mutation attempts exceeded. '
-                           'Please check optimization parameters for correctness.')
-        return individual, mutation_applied, application_attempt
+                self.agent_experience.collect_experience(individual, mutation_type, reward=-1.0)
+
+                self.log.debug(f'Number of attempts for {mutation_type} mutation application exceeded. '
+                               'Please check optimization parameters for correctness.')
+        return individual, is_applied
 
     def _sample_num_of_mutations(self) -> int:
         # most of the time returns 1 or rarely several mutations
@@ -127,33 +126,28 @@ class Mutation(Operator):
             num_mut = 1
         return num_mut
 
-    def _apply_mutations(self, new_graph: Graph) -> Tuple[Graph, Optional[MutationIdType]]:
+    def _apply_mutations(self, new_graph: Graph, mutation_type: MutationIdType) -> Graph:
         """Apply mutation 1 or few times iteratively"""
-        mutation_type = self._operator_agent.choose_action(new_graph)
-        mutation_applied = None
         for _ in range(self._sample_num_of_mutations()):
-            new_graph, applied = self._adapt_and_apply_mutation(new_graph, mutation_type)
-            if applied:
-                mutation_applied = mutation_type
-                is_custom_mutation = isinstance(mutation_type, Callable)
-                if is_custom_mutation:  # custom mutation occurs once
-                    break
-        return new_graph, mutation_applied
+            new_graph = self._adapt_and_apply_mutation(new_graph, mutation_type)
 
-    def _adapt_and_apply_mutation(self, new_graph: Graph, mutation_type) -> Tuple[Graph, bool]:
-        applied = self._will_mutation_be_applied(mutation_type)
-        if applied:
-            # get the mutation function and adapt it
-            mutation_func = self._get_mutation_func(mutation_type)
-            new_graph = mutation_func(new_graph, requirements=self.requirements,
-                                      graph_gen_params=self.graph_generation_params,
-                                      parameters=self.parameters)
-        return new_graph, applied
+            is_custom_mutation = isinstance(mutation_type, Callable)
+            if is_custom_mutation:  # custom mutation occurs once
+                break
+        return new_graph
 
-    def _will_mutation_be_applied(self, mutation_type: Union[MutationTypesEnum, Callable]) -> bool:
+    def _adapt_and_apply_mutation(self, new_graph: Graph, mutation_type: MutationIdType) -> Graph:
+        # get the mutation function and adapt it
+        mutation_func = self._get_mutation_func(mutation_type)
+        new_graph = mutation_func(new_graph, requirements=self.requirements,
+                                  graph_gen_params=self.graph_generation_params,
+                                  parameters=self.parameters)
+        return new_graph
+
+    def _will_mutation_be_applied(self, mutation_type: MutationIdType) -> bool:
         return random() <= self.parameters.mutation_prob and mutation_type is not MutationTypesEnum.none
 
-    def _get_mutation_func(self, mutation_type: Union[MutationTypesEnum, Callable]) -> Callable:
+    def _get_mutation_func(self, mutation_type: MutationIdType) -> Callable:
         if isinstance(mutation_type, Callable):
             mutation_func = mutation_type
         else:

--- a/golem/core/optimisers/genetic/operators/mutation.py
+++ b/golem/core/optimisers/genetic/operators/mutation.py
@@ -103,7 +103,7 @@ class Mutation(Operator):
 
                 new_graph = self._apply_mutations(new_graph, mutation_type)
                 is_correct_graph = self.graph_generation_params.verifier(new_graph)
-                if is_correct_graph and graph != new_graph:
+                if is_correct_graph:
                     parent_operator = ParentOperator(type_='mutation',
                                                      operators=mutation_type,
                                                      parent_individuals=individual)

--- a/golem/core/optimisers/genetic/operators/mutation.py
+++ b/golem/core/optimisers/genetic/operators/mutation.py
@@ -94,8 +94,7 @@ class Mutation(Operator):
 
     def _mutation(self, individual: Individual) -> Tuple[Individual, bool]:
         """ Function applies mutation operator to graph """
-        graph = deepcopy(individual.graph)
-        mutation_type = self._operator_agent.choose_action(graph)
+        mutation_type = self._operator_agent.choose_action(individual.graph)
         is_applied = self._will_mutation_be_applied(mutation_type)
         if is_applied:
             for _ in range(self.parameters.max_num_of_operator_attempts):

--- a/golem/core/optimisers/genetic/operators/mutation.py
+++ b/golem/core/optimisers/genetic/operators/mutation.py
@@ -118,7 +118,7 @@ class Mutation(Operator):
                                'Please check optimization parameters for correctness.')
         return individual, is_applied
 
-    def _sample_num_of_mutations(self, mutation_type: MutationIdType) -> int:
+    def _sample_num_of_mutations(self, mutation_type: Union[MutationTypesEnum, Callable]) -> int:
         # most of the time returns 1 or rarely several mutations
         is_custom_mutation = isinstance(mutation_type, Callable)
         if self.parameters.variable_mutation_num and not is_custom_mutation:
@@ -127,7 +127,7 @@ class Mutation(Operator):
             num_mut = 1
         return num_mut
 
-    def _apply_mutations(self, new_graph: Graph, mutation_type: MutationIdType) -> Graph:
+    def _apply_mutations(self, new_graph: Graph, mutation_type: Union[MutationTypesEnum, Callable]) -> Graph:
         """Apply mutation 1 or few times iteratively"""
         for _ in range(self._sample_num_of_mutations(mutation_type)):
             mutation_func = self._get_mutation_func(mutation_type)
@@ -136,10 +136,10 @@ class Mutation(Operator):
                                       parameters=self.parameters)
         return new_graph
 
-    def _will_mutation_be_applied(self, mutation_type: MutationIdType) -> bool:
+    def _will_mutation_be_applied(self, mutation_type: Union[MutationTypesEnum, Callable]) -> bool:
         return random() <= self.parameters.mutation_prob and mutation_type is not MutationTypesEnum.none
 
-    def _get_mutation_func(self, mutation_type: MutationIdType) -> Callable:
+    def _get_mutation_func(self, mutation_type: Union[MutationTypesEnum, Callable]) -> Callable:
         if isinstance(mutation_type, Callable):
             mutation_func = mutation_type
         else:

--- a/golem/core/optimisers/genetic/parameters/mutation_prob.py
+++ b/golem/core/optimisers/genetic/parameters/mutation_prob.py
@@ -9,7 +9,7 @@ class AdaptiveMutationProb(AdaptiveParameter[float]):
     def __init__(self, default_prob: float = 0.5):
         self._current_std = 0.
         self._max_std = 0.
-        self._min_proba = 0.05
+        self._min_proba = 0.1
         self._default_prob = default_prob
 
     @property

--- a/golem/core/optimisers/random_graph_factory.py
+++ b/golem/core/optimisers/random_graph_factory.py
@@ -67,4 +67,4 @@ def graph_growth(graph: OptGraph,
         if not is_max_depth_exceeded:
             # lower proba of further growth reduces time of graph generation
             if choices([0, 1], weights=[1 - growth_proba, growth_proba])[0]:
-                graph_growth(graph, node, node_factory, requirements, max_depth, growth_proba)
+                graph_growth(graph, node, node_factory, requirements, max_depth, growth_proba / max_depth)

--- a/golem/core/optimisers/random_graph_factory.py
+++ b/golem/core/optimisers/random_graph_factory.py
@@ -67,4 +67,4 @@ def graph_growth(graph: OptGraph,
         if not is_max_depth_exceeded:
             # lower proba of further growth reduces time of graph generation
             if choices([0, 1], weights=[1 - growth_proba, growth_proba])[0]:
-                graph_growth(graph, node, node_factory, requirements, max_depth, growth_proba / max_depth)
+                graph_growth(graph, node, node_factory, requirements, max_depth, growth_proba)

--- a/test/integration/test_genetic_schemes.py
+++ b/test/integration/test_genetic_schemes.py
@@ -1,9 +1,8 @@
-from functools import partial
+from typing import Sequence
 
 import numpy as np
 import pytest
 
-from examples.synthetic_graph_evolution.experiment_setup import run_trial
 from examples.synthetic_graph_evolution.generators import generate_labeled_graph
 from examples.synthetic_graph_evolution.tree_search import tree_search_setup
 from golem.core.optimisers.genetic.gp_params import GPAlgorithmParameters
@@ -17,7 +16,7 @@ def set_up_params(genetic_scheme: GeneticSchemeTypesEnum):
         multi_objective=False,
         mutation_types=[
             MutationTypesEnum.single_add,
-            MutationTypesEnum.single_drop,
+            MutationTypesEnum.single_drop
         ],
         crossover_types=[CrossoverTypesEnum.none],
         genetic_scheme_type=genetic_scheme
@@ -27,13 +26,16 @@ def set_up_params(genetic_scheme: GeneticSchemeTypesEnum):
 
 @pytest.mark.parametrize('genetic_type', GeneticSchemeTypesEnum)
 def test_genetic_scheme_types(genetic_type):
-    target_graph = generate_labeled_graph('tree', 4, node_labels=['x'])
+    target_graph = generate_labeled_graph('tree', 30, node_labels=['x'])
     num_iterations = 30
 
     gp_params = set_up_params(genetic_type)
-    found_graph, history = run_trial(target_graph=target_graph,
-                                     optimizer_setup=partial(tree_search_setup, algorithm_parameters=gp_params),
-                                     num_iterations=num_iterations)
+    optimizer, objective = tree_search_setup(target_graph,
+                                             num_iterations=num_iterations,
+                                             algorithm_parameters=gp_params)
+    found_graphs = optimizer.optimise(objective)
+    found_graph = found_graphs[0] if isinstance(found_graphs, Sequence) else found_graphs
+    history = optimizer.history
     assert found_graph is not None
     # at least 20% more generation than early_stopping_iterations were evaluated
     # (+2 gen for initial assumption and final choice)

--- a/test/integration/test_genetic_schemes.py
+++ b/test/integration/test_genetic_schemes.py
@@ -36,7 +36,8 @@ def test_genetic_scheme_types(genetic_type):
                                      num_iterations=num_iterations)
     assert found_graph is not None
     # at least 20% more generation than early_stopping_iterations were evaluated
-    assert history.generations_count >= num_iterations // 3 * 1.2
+    # (+2 gen for initial assumption and final choice)
+    assert history.generations_count >= num_iterations // 3 * 1.2 + 2
     # metric improved
     assert np.mean([ind.fitness.value for ind in history.generations[0].data]) > \
            np.mean([ind.fitness.value for ind in history.generations[-1].data])

--- a/test/unit/optimizers/gp_operators/test_mutation.py
+++ b/test/unit/optimizers/gp_operators/test_mutation.py
@@ -79,13 +79,12 @@ def test_add_as_parent_node(graph):
     Test correctness of adding as a parent
     """
     new_graph = deepcopy(graph)
-    node_to_mutate = new_graph.nodes[1]
     params = get_mutation_params()
     node_factory = params['graph_gen_params'].node_factory
 
-    add_separate_parent_node(new_graph, node_to_mutate, node_factory)
+    add_separate_parent_node(new_graph, node_factory)
 
-    assert len(node_to_mutate.nodes_from) > len(graph.nodes[1].nodes_from)
+    assert new_graph.length > graph.length
 
 
 @pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
@@ -94,14 +93,12 @@ def test_add_as_child_node(graph):
     Test correctness of adding as a child
     """
     new_graph = deepcopy(graph)
-    node_to_mutate = new_graph.nodes[1]
     params = get_mutation_params()
     node_factory = params['graph_gen_params'].node_factory
 
-    add_as_child(new_graph, node_to_mutate, node_factory)
+    add_as_child(new_graph, node_factory)
 
     assert new_graph.length > graph.length
-    assert new_graph.node_children(node_to_mutate) != graph.node_children(node_to_mutate)
 
 
 @pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])
@@ -110,14 +107,12 @@ def test_add_as_intermediate_node(graph):
     Test correctness of adding as an intermediate node
     """
     new_graph = deepcopy(graph)
-    node_to_mutate = new_graph.nodes[1]
     params = get_mutation_params()
     node_factory = params['graph_gen_params'].node_factory
 
-    add_intermediate_node(new_graph, node_to_mutate, node_factory)
+    add_intermediate_node(new_graph, node_factory)
 
     assert new_graph.length > graph.length
-    assert node_to_mutate.nodes_from[0] != graph.nodes[1].nodes_from[0]
 
 
 @pytest.mark.parametrize('graph', [simple_linear_graph(), tree_graph(), simple_cycled_graph()])

--- a/test/unit/optimizers/gp_operators/test_mutation.py
+++ b/test/unit/optimizers/gp_operators/test_mutation.py
@@ -82,8 +82,13 @@ def test_add_as_parent_node(graph):
     params = get_mutation_params()
     node_factory = params['graph_gen_params'].node_factory
 
+    prev_nodes = new_graph.nodes[:]
     add_separate_parent_node(new_graph, node_factory)
+    new_nodes = [node for node in new_graph.nodes if node not in prev_nodes]
 
+    assert len(new_nodes) == 1
+    assert not new_nodes[0].nodes_from
+    assert new_graph.node_children(new_nodes[0])
     assert new_graph.length > graph.length
 
 
@@ -96,8 +101,12 @@ def test_add_as_child_node(graph):
     params = get_mutation_params()
     node_factory = params['graph_gen_params'].node_factory
 
+    prev_nodes = new_graph.nodes[:]
     add_as_child(new_graph, node_factory)
+    new_nodes = [node for node in new_graph.nodes if node not in prev_nodes]
 
+    assert len(new_nodes) == 1
+    assert new_nodes[0].nodes_from
     assert new_graph.length > graph.length
 
 
@@ -109,9 +118,13 @@ def test_add_as_intermediate_node(graph):
     new_graph = deepcopy(graph)
     params = get_mutation_params()
     node_factory = params['graph_gen_params'].node_factory
-
+    prev_nodes = new_graph.nodes[:]
     add_intermediate_node(new_graph, node_factory)
+    new_nodes = [node for node in new_graph.nodes if node not in prev_nodes]
 
+    assert len(new_nodes) == 1
+    assert new_nodes[0].nodes_from
+    assert new_graph.node_children(new_nodes[0])
     assert new_graph.length > graph.length
 
 

--- a/test/unit/optimizers/test_random_graph_factory.py
+++ b/test/unit/optimizers/test_random_graph_factory.py
@@ -11,7 +11,7 @@ from golem.core.optimisers.optimization_parameters import GraphRequirements
 from golem.core.optimisers.random_graph_factory import RandomGrowthGraphFactory
 
 
-@pytest.mark.parametrize('max_depth', [1, 5, 10, 30, 50])
+@pytest.mark.parametrize('max_depth', [1, 5, 10, 30])
 def test_gp_composer_random_graph_generation_looping(max_depth):
     """ Test checks DefaultRandomOptGraphFactory valid generation. """
     available_node_types = ['a', 'b', 'c', 'd', 'e']

--- a/test/unit/optimizers/test_random_graph_factory.py
+++ b/test/unit/optimizers/test_random_graph_factory.py
@@ -11,7 +11,7 @@ from golem.core.optimisers.optimization_parameters import GraphRequirements
 from golem.core.optimisers.random_graph_factory import RandomGrowthGraphFactory
 
 
-@pytest.mark.parametrize('max_depth', [1, 5, 10, 30])
+@pytest.mark.parametrize('max_depth', [1, 5, 10, 30, 50])
 def test_gp_composer_random_graph_generation_looping(max_depth):
     """ Test checks DefaultRandomOptGraphFactory valid generation. """
     available_node_types = ['a', 'b', 'c', 'd', 'e']
@@ -31,4 +31,4 @@ def test_gp_composer_random_graph_generation_looping(max_depth):
         assert verifier(graph) is True
         assert graph.depth <= requirements.max_depth
     # at least one graph has depth greater than a max_depth quarter
-    assert np.any([graph.depth >= math.ceil(max_depth / 4) for graph in graphs])
+    assert np.any([graph.depth >= math.ceil(max_depth * 0.25) for graph in graphs])


### PR DESCRIPTION
Changes:
- If mutation will be applied is decided outside of the retry loop. Previously we were shooting ourselves in the foot trying to defenetly apply a mutation while deciding to apply it with some probability in the loop.
- Also the choice of the mutation type is made outside the loop to collect proper experience for the agent (now the agent can know that the exact mutation type failed to apply to the specified graph).
- Negative reward in case of unsuccesfull mutation is registered only once after several attempt. It prevents the agent of being biased.
- Base mutations now try on different nodes to make any change which makes it possible to remove equality check in the mutation operator.

Proposed changes have shown better results on synthetic task for tree graph (random bandit).
Here is mean results for 20 launches with all implemented base mutations with 50 maximal iterations and 20 min time limit. 
It can be seen that new version: 
- works faster, 
- converge in fewer iterations 
- achieves slightly better results (in tertms of mean and std).
![1](https://github.com/aimclub/GOLEM/assets/43475193/430f05f0-2dda-4494-b410-1343f926afb4)
![2](https://github.com/aimclub/GOLEM/assets/43475193/0da7c75b-32a0-40d0-9c7a-428931bbd5a5)

It is a toy experiment but still...

New version results
![image](https://github.com/aimclub/GOLEM/assets/43475193/efbc6b34-295d-41f7-bd2e-30e68036b4c4)

Old version results
![image](https://github.com/aimclub/GOLEM/assets/43475193/1f36b86a-d06e-4dd8-ad49-6b57e3059732)
