### PR TITLE
Fix hyperopt.hp.randint

### DIFF
--- a/golem/core/tuning/hyperopt_tuner.py
+++ b/golem/core/tuning/hyperopt_tuner.py
@@ -1,17 +1,26 @@
 from abc import ABC
 from datetime import timedelta
-from typing import Optional, Callable, Dict
+from typing import Callable, Dict, Optional
 
 import numpy as np
-from hyperopt import tpe, hp
+from hyperopt import hp, tpe
 from hyperopt.early_stop import no_progress_loss
-from hyperopt.pyll import Apply
+from hyperopt.pyll import Apply, scope
+from hyperopt.pyll_utils import validate_label
 
 from golem.core.adapter import BaseOptimizationAdapter
 from golem.core.log import default_log
 from golem.core.optimisers.objective import ObjectiveFunction
 from golem.core.tuning.search_space import SearchSpace, get_node_operation_parameter_label
 from golem.core.tuning.tuner_interface import BaseTuner
+
+
+@validate_label
+def hp_randint(label, *args, **kwargs):
+    return scope.int(scope.hyperopt_param(label, scope.randint(*args, **kwargs)))
+
+
+hp.randint = hp_randint
 
 
 class HyperoptTuner(BaseTuner, ABC):

--- a/test/unit/tuning/test_tuning.py
+++ b/test/unit/tuning/test_tuning.py
@@ -148,5 +148,5 @@ def test_hyperopt_returns_native_types(search_space, tuner_cls):
     tuned_graph = tuner.tune(deepcopy(graph))
     for node in tuned_graph.nodes:
         for param, val in node.parameters.items():
-            assert not hasattr(val, 'shape'), (f'The parameter "{param}" should not be a numpy type. '
-                                               f'Got "{type(val)}".')
+            assert val.__class__.__module__ != 'numpy', (f'The parameter "{param}" should not be a numpy type. '
+                                                         f'Got "{type(val)}".')

--- a/test/unit/tuning/test_tuning.py
+++ b/test/unit/tuning/test_tuning.py
@@ -40,7 +40,7 @@ def search_space():
                 'hyperopt-dist': hp.choice,
                 'sampling-scope': [['A', 'B', 'C']],
                 'type': 'categorical'
-            }        },
+            }},
         'b': {
             'b1': {
                 'hyperopt-dist': hp.choice,


### PR DESCRIPTION
Monkey-patch the `hyperopt.hp.randint` near the definition of `HyperoptTuner`.

Makes it return an `int` instead of a `np.int64`.