### PR TITLE
Remove callback

### DIFF
--- a/golem/core/tuning/optuna_tuner.py
+++ b/golem/core/tuning/optuna_tuner.py
@@ -60,7 +60,7 @@ class OptunaTuner(BaseTuner):
                                 n_trials=self.iterations,
                                 n_jobs=self.n_jobs,
                                 timeout=remaining_time,
-                                callbacks=[self.early_stopping_callback],
+                                callbacks=[self.early_stopping_callback] if not is_multi_objective else None,
                                 show_progress_bar=show_progress)
 
             if not is_multi_objective:

--- a/test/unit/tuning/test_tuning.py
+++ b/test/unit/tuning/test_tuning.py
@@ -130,7 +130,7 @@ def test_node_tuning(search_space, graph):
                                                        is_multi_objective=True)))])
 def test_multi_objective_tuning(search_space, tuner_cls, init_graph, adapter, obj_eval):
     init_metric = obj_eval.evaluate(init_graph)
-    tuner = tuner_cls(obj_eval, search_space, adapter, iterations=20)
+    tuner = tuner_cls(obj_eval, search_space, adapter, iterations=20, early_stopping_rounds=3)
     tuned_graphs = tuner.tune(deepcopy(init_graph), show_progress=False)
     for graph in tuned_graphs:
         assert type(graph) == type(init_graph)


### PR DESCRIPTION
Minor fix for `OptunaTuner`: `early_stopping_iteration` is not applicable for multi-objective problem.