### PR TITLE
Fix variance specification for GraphFunction

### DIFF
--- a/golem/core/optimisers/objective/objective.py
+++ b/golem/core/optimisers/objective/objective.py
@@ -1,15 +1,21 @@
 import itertools
 from dataclasses import dataclass
 from numbers import Real
-from typing import Any, Optional, Callable, Sequence, TypeVar, Dict, Tuple, Union
+from typing import Any, Optional, Callable, Sequence, TypeVar, Dict, Tuple, Union, Protocol
 
 from golem.core.dag.graph import Graph
 from golem.core.log import default_log
 from golem.core.optimisers.fitness import Fitness, SingleObjFitness, null_fitness, MultiObjFitness
 
-G = TypeVar('G', bound=Graph, covariant=True)
-R = TypeVar('R', contravariant=True)
-GraphFunction = Callable[[G], R]
+G = TypeVar('G', bound=Graph, contravariant=True)
+R = TypeVar('R', covariant=True)
+
+
+class GraphFunction(Protocol[G, R]):
+    def __call__(self, graph: G) -> R:
+        ...
+
+
 ObjectiveFunction = GraphFunction[G, Fitness]
 
 


### PR DESCRIPTION
Resolves #264

As demonstrated by this code snippet:
```python
from typing import Callable, TypeVar, Protocol


class SuperGraph:
    pass


class Graph(SuperGraph):
    pass


class SubGraph(Graph):
    pass

class Fitness:
    pass


G = TypeVar('G', bound=Graph, contravariant=True)
R = TypeVar('R', covariant=True)


# Instead of:
# G = TypeVar('G', bound=Graph, covariant=True)
# R = TypeVar('R', contravariant=True)

# Invariant is not versatile enough:
# G = TypeVar('G', bound=Graph)
# R = TypeVar('R')



class GraphFunction(Protocol[G, R]):
    def __call__(self, graph: G) -> R:
        ...

# Instead of:
# GraphFunction = Callable[[G], R]


def process_supergraph(graph: SuperGraph) -> int:
    return 42


def process_subgraph(graph: SubGraph) -> int:
    return 42


# This is valid: process_supergraph can be treated as GraphFunction[SubGraph, int]
graph_func: GraphFunction[SubGraph, int] = process_supergraph

# This is invalid: process_subgraph cannot be treated as GraphFunction[SuperGraph, int]
graph_func2: GraphFunction[Graph, int] = process_subgraph
```

Only the Protocol way defines the desired subtyping and passes `mypy` check.

While Callable is by default invariant over both its arguments.