### PR TITLE
fix: resolve gensim dependency on a specific commit

### DIFF
--- a/other_requirements/molecules.txt
+++ b/other_requirements/molecules.txt
@@ -3,5 +3,5 @@ guacamol>=0.5.4
 joblib>=0.12.5
 requests>=2.30.0
 mol2vec==0.2.2
-gensim>=4.3.2
+gensim @ git+https://github.com/piskvorky/gensim.git@ad68ee3
 torch>=2.0.1


### PR DESCRIPTION
quick gensim dependency resolution regarding integration tests failure

[recent gensim fix](https://github.com/piskvorky/gensim/commit/ad68ee3f105fc37cf8db333bfb837fe889ff74ac)