### PR TITLE
Restore the domain graph once per verification

### DIFF
--- a/golem/core/dag/graph_verifier.py
+++ b/golem/core/dag/graph_verifier.py
@@ -33,7 +33,7 @@ class GraphVerifier:
         # verifying graphs whose domain representation is expensive to build.
         restore = _restore_memoized(self._adapter)
         for rule in self._rules:
-            adapted_rule = rule if AdaptRegistry.is_native(rule) else                 _transform(rule, f_args=restore, f_ret=self._adapter.adapt)
+            adapted_rule = rule if AdaptRegistry.is_native(rule) else _transform(rule, f_args=restore, f_ret=self._adapter.adapt)
             try:
                 if adapted_rule(graph) is False:
                     return False

--- a/golem/core/dag/graph_verifier.py
+++ b/golem/core/dag/graph_verifier.py
@@ -1,7 +1,8 @@
 from typing import Sequence, Optional, Callable
 
 from golem.core.adapter import BaseOptimizationAdapter
-from golem.core.adapter.adapter import IdentityAdapter
+from golem.core.adapter.adapter import IdentityAdapter, _transform
+from golem.core.adapter.adapt_registry import AdaptRegistry
 from golem.core.dag.graph import Graph
 from golem.core.log import default_log
 
@@ -26,11 +27,15 @@ class GraphVerifier:
         return self.verify(graph)
 
     def verify(self, graph: Graph) -> bool:
-        # Check if all rules pass
-        adapt = self._adapter.adapt_func
+        # Check if all rules pass.
+        # The domain graph is restored at most once per verification: restoring
+        # anew for every rule, as ``adapt_func`` would, dominates the cost of
+        # verifying graphs whose domain representation is expensive to build.
+        restore = _restore_memoized(self._adapter)
         for rule in self._rules:
+            adapted_rule = rule if AdaptRegistry.is_native(rule) else                 _transform(rule, f_args=restore, f_ret=self._adapter.adapt)
             try:
-                if adapt(rule)(graph) is False:
+                if adapted_rule(graph) is False:
                     return False
             except ValueError as err:
                 msg = f'Graph verification failed with error <{err}> '\
@@ -41,3 +46,20 @@ class GraphVerifier:
                     self._log.debug(msg)
                     return False
         return True
+
+
+def _restore_memoized(adapter: BaseOptimizationAdapter) -> Callable:
+    """A ``restore`` that maps each object at most once, by identity.
+
+    Verification rules only read the domain graph, so all rules of one
+    verification can share a single restored instance.
+    """
+    memo = {}
+
+    def restore(item):
+        key = id(item)
+        if key not in memo:
+            memo[key] = adapter.restore(item)
+        return memo[key]
+
+    return restore


### PR DESCRIPTION
## Summary

`GraphVerifier` adapted every rule independently, so each rule's call restored the optimisation graph into its domain representation anew. A verification with a dozen domain rules paid for a dozen restores, and under an evolutionary run with mutation retries this dominates the time between two populations.

Profiling a FEDOT composition (fixed 12 generations, population 24, `n_jobs=4`) put **50 s of the 214 s run inside `verify`**, 40 s of which was restoring the same graphs repeatedly — with ~16 verification calls per accepted offspring due to mutation retries, that is thousands of restores per generation.

## Change

Verification rules only read the graph, so all rules of one verification now share a single restored instance via an identity-keyed memo. Natively registered rules (`AdaptRegistry.is_native`) keep receiving the optimisation graph unchanged, and the memo lives only for the duration of one `verify` call, so mutated graphs are never served stale.

## Measurements

Same fixed-work FEDOT composition, before → after:

- `verify` cumulative: 50.1 s → 20.4 s
- adapter `restore` cumulative: 39.7 s → 6.4 s
- whole run wall time: **214 s → 169 s (−21 %)**
- micro-benchmark of restore + verify for a four-node classification pipeline: 7.2 ms → 3.2 ms per call

`test/unit/dag` and `test/unit/adapter` pass, as do FEDOT's `test/unit/pipelines/test_pipeline_verification.py` and `test/unit/optimizer` against this branch.