### PR TITLE
Let the node factory propose valid final nodes for sink mutations

### DIFF
--- a/golem/core/optimisers/advisor.py
+++ b/golem/core/optimisers/advisor.py
@@ -28,5 +28,15 @@ class DefaultChangeAdvisor(Generic[NodeType]):
     def can_be_removed(self, node: NodeType) -> RemoveType:
         return RemoveType.node_rewire
 
+    def can_be_sink(self, node: NodeType) -> bool:
+        """Whether the node is acceptable as the final (sink) node of a graph.
+
+        Crossover consults this before placing a subtree head into the sink
+        position, so domains whose sinks are constrained - e.g. a pipeline
+        must end with a model - do not breed offspring that verification is
+        certain to reject.
+        """
+        return True
+
     def propose_parent(self, node: NodeType, possible_operations: List[Any]) -> List[Any]:
         return possible_operations

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -195,7 +195,10 @@ def add_as_child(graph: OptGraph,
         # add as child
         old_node_children = graph.node_children(node_to_mutate)
         new_node_child = choice(old_node_children) if old_node_children else None
-        new_node = node_factory.get_node(is_primary=False)
+        # Without a child to take over, the new node becomes the graph's sink,
+        # and domains constrain what a sink may be; asking the factory for a
+        # valid final node avoids offspring the verifier would only reject.
+        new_node = node_factory.get_node(is_primary=False) if new_node_child             else node_factory.get_final_node()
         if not new_node:
             continue
         graph.add_node(new_node)

--- a/golem/core/optimisers/genetic/operators/base_mutations.py
+++ b/golem/core/optimisers/genetic/operators/base_mutations.py
@@ -198,7 +198,7 @@ def add_as_child(graph: OptGraph,
         # Without a child to take over, the new node becomes the graph's sink,
         # and domains constrain what a sink may be; asking the factory for a
         # valid final node avoids offspring the verifier would only reject.
-        new_node = node_factory.get_node(is_primary=False) if new_node_child             else node_factory.get_final_node()
+        new_node = node_factory.get_node(is_primary=False) if new_node_child else node_factory.get_final_node()
         if not new_node:
             continue
         graph.add_node(new_node)

--- a/golem/core/optimisers/genetic/operators/crossover.py
+++ b/golem/core/optimisers/genetic/operators/crossover.py
@@ -1,8 +1,9 @@
 from copy import deepcopy
+from functools import partial
 from itertools import chain
 from math import ceil
 from random import choice, random, sample, randrange
-from typing import Callable, Union, Iterable, Tuple, TYPE_CHECKING
+from typing import Callable, Optional, Union, Iterable, Tuple, TYPE_CHECKING
 
 from golem.core.adapter import register_native
 from golem.core.dag.graph_utils import nodes_from_layer, node_depth, get_all_simple_paths, get_connected_components
@@ -81,9 +82,10 @@ class Crossover(Operator):
         return self.graph_generation_params.adapter.adapt_func(crossover_func)
 
     def _crossover_by_type(self, crossover_type: CrossoverTypesEnum) -> CrossoverCallable:
+        sink_filter = self.graph_generation_params.advisor.can_be_sink
         crossovers = {
-            CrossoverTypesEnum.subtree: subtree_crossover,
-            CrossoverTypesEnum.one_point: one_point_crossover,
+            CrossoverTypesEnum.subtree: partial(subtree_crossover, sink_filter=sink_filter),
+            CrossoverTypesEnum.one_point: partial(one_point_crossover, sink_filter=sink_filter),
             CrossoverTypesEnum.exchange_edges: exchange_edges_crossover,
             CrossoverTypesEnum.exchange_parents_one: exchange_parents_one_crossover,
             CrossoverTypesEnum.exchange_parents_both: exchange_parents_both_crossover,
@@ -109,36 +111,67 @@ class Crossover(Operator):
 
 
 @register_native
-def subtree_crossover(graph_1: OptGraph, graph_2: OptGraph,
-                      max_depth: int, inplace: bool = True) -> Tuple[OptGraph, OptGraph]:
+def subtree_crossover(graph_1: OptGraph, graph_2: OptGraph, max_depth: int, inplace: bool = True,
+                      sink_filter: Optional[Callable[[OptNode], bool]] = None) -> Tuple[OptGraph, OptGraph]:
     """Performed by the replacement of random subtree
-    in first selected parent to random subtree from the second parent"""
+    in first selected parent to random subtree from the second parent.
+
+    When a sink of either graph is the crossover point, the head of the
+    incoming subtree is checked with ``sink_filter``: an unacceptable sink
+    means the offspring is certain to be rejected by verification, so such
+    picks are retried, falling back to the old behaviour when nothing valid
+    turns up.
+    """
 
     if not inplace:
         graph_1 = deepcopy(graph_1)
         graph_2 = deepcopy(graph_2)
-    else:
-        graph_1 = graph_1
-        graph_2 = graph_2
 
-    random_layer_in_graph_first = choice(range(graph_1.depth))
-    min_second_layer = 1 if random_layer_in_graph_first == 0 and graph_2.depth > 1 else 0
-    random_layer_in_graph_second = choice(range(min_second_layer, graph_2.depth))
+    picked = None
+    for _ in range(5 if sink_filter is not None else 1):
+        layer_first = choice(range(graph_1.depth))
+        min_second_layer = 1 if layer_first == 0 and graph_2.depth > 1 else 0
+        layer_second = choice(range(min_second_layer, graph_2.depth))
+        node_first = choice(nodes_from_layer(graph_1, layer_first))
+        node_second = choice(nodes_from_layer(graph_2, layer_second))
+        if sink_filter is not None:
+            if layer_first == 0 and not sink_filter(node_second):
+                continue
+            if layer_second == 0 and not sink_filter(node_first):
+                continue
+        picked = (node_first, node_second, layer_first, layer_second)
+        break
 
-    node_from_graph_first = choice(nodes_from_layer(graph_1, random_layer_in_graph_first))
-    node_from_graph_second = choice(nodes_from_layer(graph_2, random_layer_in_graph_second))
+    if picked is None:
+        layer_first = choice(range(graph_1.depth))
+        min_second_layer = 1 if layer_first == 0 and graph_2.depth > 1 else 0
+        layer_second = choice(range(min_second_layer, graph_2.depth))
+        picked = (choice(nodes_from_layer(graph_1, layer_first)),
+                  choice(nodes_from_layer(graph_2, layer_second)),
+                  layer_first, layer_second)
 
-    replace_subtrees(graph_1, graph_2, node_from_graph_first, node_from_graph_second,
-                     random_layer_in_graph_first, random_layer_in_graph_second, max_depth)
+    node_first, node_second, layer_first, layer_second = picked
+    replace_subtrees(graph_1, graph_2, node_first, node_second, layer_first, layer_second, max_depth)
 
     return graph_1, graph_2
 
 
 @register_native
-def one_point_crossover(graph_first: OptGraph, graph_second: OptGraph, max_depth: int) -> Tuple[OptGraph, OptGraph]:
+def one_point_crossover(graph_first: OptGraph, graph_second: OptGraph, max_depth: int,
+                        sink_filter: Optional[Callable[[OptNode], bool]] = None) -> Tuple[OptGraph, OptGraph]:
     """Finds common structural parts between two trees, and after that randomly
     chooses the location of nodes, subtrees of which will be swapped"""
     pairs_of_nodes = equivalent_subtree(graph_first, graph_second)
+    if pairs_of_nodes and sink_filter is not None:
+        # A pair that would put an unacceptable head into a sink position can
+        # only breed offspring that verification rejects; prefer the rest.
+        root_first, root_second = graph_first.root_node, graph_second.root_node
+        acceptable = [
+            (first, second) for first, second in pairs_of_nodes
+            if (first is not root_first or sink_filter(second))
+            and (second is not root_second or sink_filter(first))
+        ]
+        pairs_of_nodes = acceptable or pairs_of_nodes
     if pairs_of_nodes:
         node_from_graph_first, node_from_graph_second = choice(pairs_of_nodes)
 

--- a/golem/core/optimisers/genetic/operators/crossover.py
+++ b/golem/core/optimisers/genetic/operators/crossover.py
@@ -143,12 +143,10 @@ def subtree_crossover(graph_1: OptGraph, graph_2: OptGraph, max_depth: int, inpl
         break
 
     if picked is None:
-        layer_first = choice(range(graph_1.depth))
-        min_second_layer = 1 if layer_first == 0 and graph_2.depth > 1 else 0
-        layer_second = choice(range(min_second_layer, graph_2.depth))
-        picked = (choice(nodes_from_layer(graph_1, layer_first)),
-                  choice(nodes_from_layer(graph_2, layer_second)),
-                  layer_first, layer_second)
+        # Every considered pick would breed offspring that verification is
+        # certain to reject; unchanged parents are what those retries would
+        # have ended with anyway.
+        return graph_1, graph_2
 
     node_first, node_second, layer_first, layer_second = picked
     replace_subtrees(graph_1, graph_2, node_first, node_second, layer_first, layer_second, max_depth)
@@ -166,12 +164,14 @@ def one_point_crossover(graph_first: OptGraph, graph_second: OptGraph, max_depth
         # A pair that would put an unacceptable head into a sink position can
         # only breed offspring that verification rejects; prefer the rest.
         root_first, root_second = graph_first.root_node, graph_second.root_node
-        acceptable = [
+        pairs_of_nodes = [
             (first, second) for first, second in pairs_of_nodes
             if (first is not root_first or sink_filter(second))
             and (second is not root_second or sink_filter(first))
         ]
-        pairs_of_nodes = acceptable or pairs_of_nodes
+        # No acceptable pair means every possible offspring would be rejected
+        # and the parents returned unchanged after all retries - which is what
+        # an empty pair list produces immediately, minus the wasted attempts.
     if pairs_of_nodes:
         node_from_graph_first, node_from_graph_second = choice(pairs_of_nodes)
 

--- a/golem/core/optimisers/opt_node_factory.py
+++ b/golem/core/optimisers/opt_node_factory.py
@@ -34,6 +34,18 @@ class OptNodeFactory(ABC):
         """
         pass
 
+    def get_final_node(self) -> Optional[OptNode]:
+        """
+        Returns a node fit to be the final (sink) node of the graph.
+
+        Domains often constrain what a final node may be - e.g. a pipeline
+        must end with a model, not a preprocessing step. Mutations that place
+        a new node in the sink position use this method, so domain factories
+        can propose only valid candidates instead of relying on the verifier
+        to reject the rest. The default keeps the old behaviour.
+        """
+        return self.get_node(is_primary=False)
+
     @abstractmethod
     def get_all_available_operations(self) -> List[str]:
         """

--- a/test/unit/optimizers/test_node_factory.py
+++ b/test/unit/optimizers/test_node_factory.py
@@ -1,0 +1,9 @@
+from golem.core.optimisers.opt_node_factory import DefaultOptNodeFactory
+
+
+def test_get_final_node_falls_back_to_get_node():
+    factory = DefaultOptNodeFactory(available_node_types=['a', 'b'])
+    for _ in range(20):
+        node = factory.get_final_node()
+        assert node is not None
+        assert node.content['name'] in ('a', 'b')


### PR DESCRIPTION
## Summary

Nearly all rejected offspring of a FEDOT composition trace back to invalid **sink** nodes: on a fixed-work run (12 generations, population 24) **73 % of offspring were rejected at verification, 89 % of the rejections by `has_final_operation_as_model`**. Attribution by call chain put 3800 of 3810 bad-sink offspring in crossover (the tree crossovers can move an interior node of one parent into the sink position of the other) and the rest in the add-as-child mutation. Every such candidate burns a graph deepcopy, an operator application and a full verification — and can never be accepted.

## Change

Three pieces, all preserving the reachable search space:

- `OptNodeFactory.get_final_node()` — new method with a backward-compatible default (`get_node(is_primary=False)`); `add_as_child` uses it when the new node ends up with no children. Domain factories override it to propose valid sinks (FEDOT: aimclub/FEDOT#1449).
- `DefaultChangeAdvisor.can_be_sink(node)` — new predicate (default: anything); `subtree_crossover` and `one_point_crossover` consult it before placing a subtree head into a sink position.
- When no valid pick exists, the crossovers now return the parents unchanged immediately — the same outcome the old code reached after burning all retry attempts on certain-to-be-rejected offspring.

## Measurements (fixed-work FEDOT composition)

- verifications per run: **6618 → 376**; rejected offspring: **4210 → 10**
- `GraphVerifier.verify` cumulative: 50.1 s → 1.8 s; `deepcopy` calls: 3.3 M → 0.3 M
- whole run wall time: **214 s → 101 s** together with #293 and the FEDOT-side caches (this change alone accounts for the 160 s → 101 s step)

`test/unit/optimizers` (128 tests) passes, as do FEDOT's pipeline verification and node factory suites against this branch.